### PR TITLE
fix creating config for domains with more than 1 alternative name

### DIFF
--- a/getssl
+++ b/getssl
@@ -304,8 +304,8 @@ RENEW_ALLOW=\"30\"
         echo "$EX_CERT" > $DOMAIN_DIR/${DOMAIN}.crt
       fi
       EX_SANS=$(echo "$EX_CERT" | openssl x509 -noout -text 2>/dev/null| grep "Subject Alternative Name" -A2 \
-                | grep -Eo "DNS:[a-zA-Z 0-9.]*" |sed "s@DNS:$DOMAIN@@g"| cut -c 5-)
-      EX_SANS=${EX_SANS//$'\n'/}
+                | grep -Eo "DNS:[a-zA-Z 0-9.]*" | sed "s@DNS:$DOMAIN@@g" | grep -v '^$' | cut -c 5-)
+      EX_SANS=${EX_SANS//$'\n'/','}
     fi
     echo "# uncomment and modify any variables you need
 # The staging server is best for testing


### PR DESCRIPTION
i added (grep -v '^$') to remove empty lines, and replace \n with a comma.

tested with ./getssl -c example.com to get
> SANS=www.example.org,example.edu,example.net,example.org,www.example.com,www.example.edu,www.example.net

instead of
> SANS=www.example.orgexample.eduexample.netexample.orgwww.example.comwww.example.eduwww.example.net
