### PR TITLE
reload-cmd-fix

### DIFF
--- a/getssl
+++ b/getssl
@@ -702,7 +702,7 @@ fi
 
 if [ ! -z "$RELOAD_CMD" ]; then
   info "reloading SSL services"
-  if [[ "${ACL[$dn]:0:4}" == "ssh:" ]] ; then
+  if [[ "${RELOAD_CMD:0:4}" == "ssh:" ]] ; then
     sshhost=$(echo "$RELOAD_CMD"| awk -F: '{print $2}')
     command=${RELOAD_CMD:(( ${#sshhost} + 5))}
     debug "running following comand to reload cert"


### PR DESCRIPTION
it looks at ACL for ssh: and then tries to get it from RELOAD_CMD...
seems to me it should check for ssh: in the RELOAD_CMD

i switched a config to dns-challenge and then found it didn't reload apache on the server...