### PR TITLE
extra-wait-for-dns

### DIFF
--- a/getssl
+++ b/getssl
@@ -547,18 +547,19 @@ for d in $alldomains; do
 
     ntries=0
     check_dns="fail"
-    while [[ "$check_dns" == "fail" ]]; do
-
+    while [ "$check_dns" == "fail" ]; do
       check_result=$(nslookup -type=txt _acme-challenge.${d} ${primary_ns} | grep ^_acme|awk -F'"' '{ print $2}')
       debug result "$check_result"
 
       if [[ "$check_result" == "$auth_key" ]]; then
         check_dns="success"
         debug "checking DNS ... _acme-challenge.$d gave $check_result"
+        info "sleeping 60 seconds before asking letsencrypt to check the dns"
+        sleep 60 # smallest time for DNS TTL
       else
         if [[ $ntries -lt 100 ]]; then
           ntries=$(( $ntries + 1 ))
-          info "testing DNS. Attempt $ntries completed. waiting 10 secs before testing verify again"
+          info "testing DNS. Attempt $ntries/100 completed. waiting 10 secs before testing verify again"
           sleep 10
         else
           debug "dns check failed - removing existing value"
@@ -567,7 +568,6 @@ for d in $alldomains; do
         fi
       fi
     done
-
   else      # set up the correct http token for verification
     http01=$(echo $response | egrep -o  '{[^{]*"type":"http-01"[^}]*')
     debug http01 "$http01"


### PR DESCRIPTION
i was testing with the DNS-challenge yesterday and found that it would sometimes fail, this might be because of caching so i added a 60 second sleep to make sure the minimum TTL would be over.

also my DNS-provider has multiple hosts behind the same IP which don't sync at exactly the same time, so when requesting multiple times you could get a correct result and 5 seconds later get a wrong one.
with the extra 60 seconds this doesn't happen.

would you prefer if i change this to a config-variable? i personally don't mind the extra wait, since the DNS-challenge isn't the fastest way to go anyway...