### PR TITLE
do nslookup on each domain before starting requests

### DIFF
--- a/getssl
+++ b/getssl
@@ -610,6 +610,16 @@ else
 fi
 debug "created SAN list = $SANLIST"
 
+# check nslookup for domains
+alldomains=$(echo "$DOMAIN,$SANS" | sed "s/,/ /g")
+for d in $alldomains; do
+  debug "checking nslookup for ${d}"
+  exists=$(nslookup "${d}")
+  if [ "$?" != "0" ]; then
+    error_exit "DNS lookup failed for $d"
+  fi
+done
+
 # check if domain csr exists - if not then create it
 if [ -f "$DOMAIN_DIR/${DOMAIN}.csr" ]; then
   debug "domain csr exists at - $DOMAIN_DIR/${DOMAIN}.csr - skipping generation"


### PR DESCRIPTION
for the DNS-challenge and for the webserver type it is needed that the DNS entry for the domain exists.

it is not strictly necessary to check this for all domains, but when a domain does not exists you'll get an error when trying to lookup the nameserver or when trying to reach the webserver.