### PR TITLE
Respect -w when using -a

### DIFF
--- a/getssl
+++ b/getssl
@@ -717,7 +717,7 @@ if [ ${_CHECK_ALL} -eq 1 ]; then
   for dir in ${DOMAIN_STORAGE}/*; do
     if [ -d "$dir" ]; then
       debug "Checking $dir"
-      cmd="$0"
+      cmd="$0 -w $WORKING_DIR"
       if [ ${_USE_DEBUG} -eq 1 ]; then
         cmd="$cmd -d"
       fi

--- a/getssl
+++ b/getssl
@@ -717,14 +717,14 @@ if [ ${_CHECK_ALL} -eq 1 ]; then
   for dir in ${DOMAIN_STORAGE}/*; do
     if [ -d "$dir" ]; then
       debug "Checking $dir"
-      cmd="$0 -w $WORKING_DIR"
+      cmd="$0"
       if [ ${_USE_DEBUG} -eq 1 ]; then
         cmd="$cmd -d"
       fi
       if [ ${_QUIET} -eq 1 ]; then
         cmd="$cmd -q"
       fi
-      cmd="$cmd $(basename "$dir")"
+      cmd="$cmd -w $WORKING_DIR $(basename "$dir")"
 
       debug "CMD: $cmd"
       eval "$cmd"


### PR DESCRIPTION
$WORKING_DIR should always be correct so always passing it along should be the most efficient way to make sure the original -w is respected, right?