### PR TITLE
Removed check for ${TOKEN} from dns_del_pdns-mysql, as it appears it …

### DIFF
--- a/dns_scripts/dns_del_pdns-mysql
+++ b/dns_scripts/dns_del_pdns-mysql
@@ -7,12 +7,11 @@
 #CREDENTIALS="-uUSERNAME -pPASSWORD"
 
 FQDN=$1
-TOKEN=$2
 
 # If your database name is not powerdns, change it here.
 DB="powerdns"
 
 mysql -ss ${CREDENTIALS} -e "DELETE FROM ${DB}.records WHERE \
- name = '_acme-challenge.${FQDN}' AND content = '${TOKEN}';"
+ name = '_acme-challenge.${FQDN}';"
 
-echo "DELETE FROM ${DB}.records WHERE name = '_acme-challenge.${FQDN}' AND content = '${TOKEN}';"
+echo "DELETE FROM ${DB}.records WHERE name = '_acme-challenge.${FQDN}';"

--- a/getssl
+++ b/getssl
@@ -537,8 +537,8 @@ write_domain_template() { # write out a template file for a domain.
 	#DOMAIN_CERT_LOCATION="ssh:server5:/etc/ssl/domain.crt"
 	#DOMAIN_KEY_LOCATION="ssh:server5:/etc/ssl/domain.key"
 	#CA_CERT_LOCATION="/etc/ssl/chain.crt"
-	#DOMAIN_CHAIN_LOCATION="" this is the domain cert and CA cert
-	#DOMAIN_PEM_LOCATION="" this is the domain_key. domain cert and CA cert
+	#DOMAIN_CHAIN_LOCATION="" # this is the domain cert and CA cert
+	#DOMAIN_PEM_LOCATION="" # this is the domain_key. domain cert and CA cert
 
 	# The command needed to reload apache / nginx or whatever you use
 	#RELOAD_CMD=""


### PR DESCRIPTION
…is not sent to the DNS_DEL_COMMAND

Added secondary #s to the default config, so that when the affected lines are uncommented, they function properly.