### PR TITLE
add more server-types based on openssl s_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Obtain SSL certificates from the letsencrypt.org ACME server.  Suitable for auto
 * **Get certificates for remote servers** - The tokens used to provide validation of domain ownership, and the certificates themselves can be automatically copied to remote servers (via ssh, sftp or ftp for tokens). The script doesn't need to run on the server itself. This can be useful if you don't have access to run such scripts on the server itself, as it's a shared server for example.
 * **Runs as a daily cron** - so certificates will be automatically renewed when required.
 * **Automatic certificate renewals**
-* **Checks certificates are correctly loaded**. After installation of a new certificate it will test the port specified ( typically https / 443) that the certificate is actually being used correctly. 
+* **Checks certificates are correctly loaded**. After installation of a new certificate it will test the port specified ( see [Server-Types](#server-types) for options ) that the certificate is actually being used correctly. 
 * **Automatically updates** - The script can automatically update itself with bug fixes etc if required.
 * **Extensively configurable** - With a simple configuration file for each certificate it is possible to configure it exactly for your needs, whether a simple single domain or multiple domains across multiple servers on the same certificate.
 * **Supports http and dns challenges** - Full ACME implementation
@@ -172,10 +172,11 @@ RELOAD_CMD="service apache2 reload"
 # The time period within which you want to allow renewal of a certificate - this prevents hitting some of the rate limits.
 #RENEW_ALLOW="30"
 
-# Define the server type.  The can either webserver, ldaps or a port number which
+# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
 # will be checked for certificate expiry and also will be checked after
 # an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
-#SERVER_TYPE="webserver"
+#SERVER_TYPE="https"
 #CHECK_REMOTE="true"
 
 # Use the following 3 variables if you want to validate via DNS
@@ -193,6 +194,29 @@ If an ACL starts with ftp: or sftp: it as assumed that the line is in the format
 Note:  FTP can be used for copying tokens only and can **not** be used for uploading private key or certificates as it's not a secure method of transfer.
 
 ssh can also be used for the reload command if using on remote servers.
+
+
+## Server-Types
+OpenSSL has built-in support for getting the certificate from a number of SSL services
+these are available in getssl to check if the certificate is installed correctly
+
+| Server-Type      | Port | Extra        |
+|------------------|------|--------------|
+| https            | 443  |              |
+| ftp              | 21   | FTP Explicit |
+| ftpi             | 990  | FTP Implicit |
+| imap             | 143  | StartTLS     |
+| imaps            | 993  |              |
+| pop3             | 110  | StartTLS     |
+| pop3s            | 995  |              |
+| smtp             | 25   | StartTLS     |
+| smtps_deprecated | 465  |              |
+| smtps            | 587  | StartTLS     |
+| smtp_submission  | 587  | StartTLS     |
+| xmpp             | 5222 | StartTLS     |
+| xmpps            | 5269 |              |
+| ldaps            | 636  |              |
+| port number      |      |              |
 
 
 ## Issues / problems / help

--- a/create-getssl-config
+++ b/create-getssl-config
@@ -36,7 +36,7 @@ VALIDATE_VIA_DNS="false"
 RELOAD_CMD=""
 RENEW_ALLOW="30"
 PRIVATE_KEY_ALG="rsa"
-SERVER_TYPE="webserver"
+SERVER_TYPE="https"
 CHECK_REMOTE="true"
 DNS_EXTRA_WAIT=0
 
@@ -135,10 +135,11 @@ write_getssl_template() { # write out the main template file
 	#  this prevents hitting some of the rate limits.
 	RENEW_ALLOW="30"
 
-	# Define the server type.  The can either webserver, ldaps or a port number which
+	# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+	# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
 	# will be checked for certificate expiry and also will be checked after
 	# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
-	SERVER_TYPE="webserver"
+	SERVER_TYPE="https"
 	CHECK_REMOTE="true"
 
 	# openssl config file.  The default should work in most cases.
@@ -194,7 +195,8 @@ write_domain_template() { # write out a template file for a domain.
 	#  this prevents hitting some of the rate limits.
 	RENEW_ALLOW="$RENEW_ALLOW"
 
-	# Define the server type.  The can either webserver, ldaps or a port number which
+	# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+	# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
 	# will be checked for certificate expiry and also will be checked after
 	# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
 	SERVER_TYPE="$SERVER_TYPE"
@@ -330,24 +332,54 @@ CHECK_REMOTE=$res
 
 if [[ "$CHECK_REMOTE" == "true" ]]; then
   get_user_input "server type" "$SERVER_TYPE" \
-    "This can be 'webserver', 'ldap', or a port number that getssl will use for certifcate checks"
+    "This can be 'https', 'ftp', 'ftpi', 'imap', 'imaps', 'pop3', 'pop3s', 'smtp', 'smtps_deprecated', 'smtps', 'smtp_submission', 'xmpp', 'xmpps', 'ldaps' or a port number that getssl will use for certifcate checks"
   SERVER_TYPE=$res
 else
   SERVER_TYPE=""
 fi
 
-if [[ ${SERVER_TYPE} == "webserver" ]]; then
+if [[ ${SERVER_TYPE} == "https" ]] || [[ ${SERVER_TYPE} == "webserver" ]]; then
   REMOTE_PORT=443
+elif [[ ${SERVER_TYPE} == "ftp" ]]; then
+  REMOTE_PORT=21
+  REMOTE_EXTRA="-starttls ftp"
+elif [[ ${SERVER_TYPE} == "ftpi" ]]; then
+  REMOTE_PORT=990
+elif [[ ${SERVER_TYPE} == "imap" ]]; then
+  REMOTE_PORT=143
+  REMOTE_EXTRA="-starttls imap"
+elif [[ ${SERVER_TYPE} == "imaps" ]]; then
+  REMOTE_PORT=993
+elif [[ ${SERVER_TYPE} == "pop3" ]]; then
+  REMOTE_PORT=110
+  REMOTE_EXTRA="-starttls pop3"
+elif [[ ${SERVER_TYPE} == "pop3s" ]]; then
+  REMOTE_PORT=995
+elif [[ ${SERVER_TYPE} == "smtp" ]]; then
+  REMOTE_PORT=25
+  REMOTE_EXTRA="-starttls smtp"
+elif [[ ${SERVER_TYPE} == "smtps_deprecated" ]]; then
+  REMOTE_PORT=465
+elif [[ ${SERVER_TYPE} == "smtps" ]] || [[ ${SERVER_TYPE} == "smtp_submission" ]]; then
+  REMOTE_PORT=587
+  REMOTE_EXTRA="-starttls smtp"
+elif [[ ${SERVER_TYPE} == "xmpp" ]]; then
+  REMOTE_PORT=5222
+  REMOTE_EXTRA="-starttls xmpp"
+elif [[ ${SERVER_TYPE} == "xmpps" ]]; then
+  REMOTE_PORT=5269
 elif [[ ${SERVER_TYPE} == "ldaps" ]]; then
   REMOTE_PORT=636
 elif [[ ${SERVER_TYPE} =~ ^[0-9]+$ ]]; then
-  REMOTE_PORT=SERVER_TYPE
+  REMOTE_PORT=${SERVER_TYPE}
+else
+  error_exit "unknown server type"
 fi
 
 SANS="www.${DOMAIN}"
 if [[ ! -z ${REMOTE_PORT} ]]; then
   # Additional domains - this could be multiple domains / subdomains in a comma separated list
-  EX_CERT=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" 2>/dev/null | openssl x509 2>/dev/null)
+  EX_CERT=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null | openssl x509 2>/dev/null)
   if [ ! -z "${EX_CERT}" ]; then
     SANS=$(echo "$EX_CERT" | openssl x509 -noout -text 2>/dev/null| grep "Subject Alternative Name" -A2 \
               | grep -Eo "DNS:[a-zA-Z 0-9.-]*" | sed "s@DNS:$DOMAIN@@g" | grep -v '^$' | cut -c 5-)

--- a/getssl
+++ b/getssl
@@ -102,7 +102,7 @@ VALIDATE_VIA_DNS=""
 RELOAD_CMD=""
 RENEW_ALLOW="30"
 PRIVATE_KEY_ALG="rsa"
-SERVER_TYPE="webserver"
+SERVER_TYPE="https"
 CHECK_REMOTE="true"
 DNS_WAIT=10
 DNS_EXTRA_WAIT=""
@@ -552,10 +552,11 @@ write_domain_template() { # write out a template file for a domain.
 	#  this prevents hitting some of the rate limits.
 	RENEW_ALLOW="30"
 
-	# Define the server type.  This can either be a webserver, ldaps or a port number which
+	# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+	# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
 	# will be checked for certificate expiry and also will be checked after
 	# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
-	#SERVER_TYPE="webserver"
+	#SERVER_TYPE="https"
 	#CHECK_REMOTE="true"
 
 	# Use the following 3 variables if you want to validate via DNS
@@ -592,10 +593,11 @@ write_getssl_template() { # write out the main template file
 	#  this prevents hitting some of the rate limits.
 	RENEW_ALLOW="30"
 
-	# Define the server type.  This can either be a webserver, ldaps or a port number which
+	# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+	# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
 	# will be checked for certificate expiry and also will be checked after
 	# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
-	SERVER_TYPE="webserver"
+	SERVER_TYPE="https"
 	CHECK_REMOTE="true"
 
 	# openssl config file.  The default should work in most cases.
@@ -797,8 +799,36 @@ if [ -f "$DOMAIN_DIR/getssl.cfg" ]; then
   . "$DOMAIN_DIR/getssl.cfg"
 fi
 
-if [[ ${SERVER_TYPE} == "webserver" ]]; then
+if [[ ${SERVER_TYPE} == "https" ]] || [[ ${SERVER_TYPE} == "webserver" ]]; then
   REMOTE_PORT=443
+elif [[ ${SERVER_TYPE} == "ftp" ]]; then
+  REMOTE_PORT=21
+  REMOTE_EXTRA="-starttls ftp"
+elif [[ ${SERVER_TYPE} == "ftpi" ]]; then
+  REMOTE_PORT=990
+elif [[ ${SERVER_TYPE} == "imap" ]]; then
+  REMOTE_PORT=143
+  REMOTE_EXTRA="-starttls imap"
+elif [[ ${SERVER_TYPE} == "imaps" ]]; then
+  REMOTE_PORT=993
+elif [[ ${SERVER_TYPE} == "pop3" ]]; then
+  REMOTE_PORT=110
+  REMOTE_EXTRA="-starttls pop3"
+elif [[ ${SERVER_TYPE} == "pop3s" ]]; then
+  REMOTE_PORT=995
+elif [[ ${SERVER_TYPE} == "smtp" ]]; then
+  REMOTE_PORT=25
+  REMOTE_EXTRA="-starttls smtp"
+elif [[ ${SERVER_TYPE} == "smtps_deprecated" ]]; then
+  REMOTE_PORT=465
+elif [[ ${SERVER_TYPE} == "smtps" ]] || [[ ${SERVER_TYPE} == "smtp_submission" ]]; then
+  REMOTE_PORT=587
+  REMOTE_EXTRA="-starttls smtp"
+elif [[ ${SERVER_TYPE} == "xmpp" ]]; then
+  REMOTE_PORT=5222
+  REMOTE_EXTRA="-starttls xmpp"
+elif [[ ${SERVER_TYPE} == "xmpps" ]]; then
+  REMOTE_PORT=5269
 elif [[ ${SERVER_TYPE} == "ldaps" ]]; then
   REMOTE_PORT=636
 elif [[ ${SERVER_TYPE} =~ ^[0-9]+$ ]]; then
@@ -810,7 +840,7 @@ fi
 # if check_remote is true then connect and obtain the current certificate (if not forcing renewal)
 if [[ "${CHECK_REMOTE}" == "true" ]] && [ $_FORCE_RENEW -eq 0 ]; then
   debug "getting certificate for $DOMAIN from remote server"
-  EX_CERT=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" 2>/dev/null | openssl x509 2>/dev/null)
+  EX_CERT=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null | openssl x509 2>/dev/null)
   if [ ! -z "$EX_CERT" ]; then # if obtained a cert
     if [ -f "$CERT_FILE" ]; then # if local exists
       CERT_REMOTE=$(echo "$EX_CERT" | openssl x509 -noout -fingerprint 2>/dev/null)
@@ -1255,7 +1285,7 @@ reload_service
 
 # Check if the certificate is installed correctly
 if [[ ${CHECK_REMOTE} == "true" ]]; then
-  CERT_REMOTE=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" 2>/dev/null | openssl x509 -noout -fingerprint 2>/dev/null)
+  CERT_REMOTE=$(echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null | openssl x509 -noout -fingerprint 2>/dev/null)
   CERT_LOCAL=$(openssl x509 -noout -fingerprint < "$CERT_FILE" 2>/dev/null)
   if [ "$CERT_LOCAL" == "$CERT_REMOTE" ]; then
     info "certificate installed OK on server"


### PR DESCRIPTION
i added the server types which are available in openssl s_client to getssl
this way you can check if the certificate has been installed correctly on more than just web and ldap servers

i will add some documentation in the next couple of days, but i wanted some feedback on the SERVER_TYPE naming.
i think for consistency it might be better to rename "webserver" to "https" (but keep "webserver" as fallback)