### PR TITLE
Update agreement URL in a couple more places for config generation

### DIFF
--- a/getssl
+++ b/getssl
@@ -518,7 +518,7 @@ write_domain_template() { # write out a template file for a domain.
 	# This server issues full certificates, however has rate limits
 	#CA="https://acme-v01.api.letsencrypt.org"
 
-	#AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
+	#AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
 
 	# Set an email address associated with your account - generally set at account level rather than domain.
 	#ACCOUNT_EMAIL="me@example.com"
@@ -581,7 +581,7 @@ write_getssl_template() { # write out the main template file
 	# This server issues full certificates, however has rate limits
 	#CA="https://acme-v01.api.letsencrypt.org"
 
-	AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
+	AGREEMENT="https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
 
 	# Set an email address associated with your account - generally set at account level rather than domain.
 	#ACCOUNT_EMAIL="me@example.com"


### PR DESCRIPTION
The agreement URL is out of date in a couple of places in the getssl script. This leads config files being generated with the wrong AGREEMENT value, which results in the error `getssl: Error registering account` when attempting to retreive a new certificate. Running with debug on ends with the following message
```
response {
  "type": "urn:acme:error:malformed",
  "detail": "Provided agreement URL [https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf] does not match current agreement URL [https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf]",
  "status": 400
}
code 400
getssl: Error registering account
```
This PR just updates the remaining occurrences (one of them is just a comment, the other seems to affect the global (`~/.getssl/getssl.cfg`) value.