### PR TITLE
Do not check certificate validity

### DIFF
--- a/getssl
+++ b/getssl
@@ -1166,7 +1166,7 @@ for d in $alldomains; do
     debug wellknown_url "$wellknown_url"
 
     # check that we can reach the challenge ourselves, if not, then error
-    if [ ! "$(curl --silent --location "$wellknown_url")" == "$keyauthorization" ]; then
+    if [ ! "$(curl -k --silent --location "$wellknown_url")" == "$keyauthorization" ]; then
       error_exit "for some reason could not reach $wellknown_url - please check it manually"
     fi
 


### PR DESCRIPTION
If http redirects to https and currently there is no valid certificate we should still be able to retrieve the $wellknown_url