### PR TITLE
Set OPENSSL_CONF

### DIFF
--- a/getssl
+++ b/getssl
@@ -718,6 +718,9 @@ CERT_FILE="$DOMAIN_DIR/${DOMAIN}.crt"
 CA_CERT="$DOMAIN_DIR/chain.crt"
 TEMP_DIR="$DOMAIN_DIR/tmp"
 
+# Set the OPENSSL_CONF environment variable so openssl knows which config to use
+export OPENSSL_CONF=$SSLCONF
+
 # if "-a" option then check other parameters and create run for each domain.
 if [ ${_CHECK_ALL} -eq 1 ]; then
   info "Check all certificates"


### PR DESCRIPTION
OPENSSL_CONF needs to be set otherwise the SSLCONF option has no effect on the execution of all the openssl commands.