### PR TITLE
Emphasized "will use untrusted by default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ copying private key to ssh:server5:/home/yourdomain/ssl/domain.key
 copying CA certificate to ssh:server5:/home/yourdomain/ssl/chain.crt
 reloading SSL services
 ```
-This will (by default) use the staging server, so should give you a certificate that isn't trusted ( Fake Let's Encrypt).
+**This will (by default) use the staging server, so should give you a certificate that isn't trusted ( Fake Let's Encrypt).**
 Change the server in your config file to get a fully valid certificate.
 
 **Note:**   Verification is done via port 80(http), port 443(https) or dns.  The certificate can be used ( and checked with getssl) on alternate ports.


### PR DESCRIPTION
It's entirely my fault for killing a production site for 10 minutes while I figured this out, and for not making a backup of the working private key and certificate, but I think it would help people to emphasize that it uses the staging server by default.

Especially since changing the setting doesn't work unless you remove the old certificate from `~/.getssl/$domain` first, which took another few minutes to figure out. The script will not detect that the certificate is untrusted and goes "oh I'm all done already, it's still valid for a while".

(Other than that, 10/10! So much simpler and better than the default letsencrypt client, loved it.)