### PR TITLE
No update checks during recursive calls for --all processing

### DIFF
--- a/getssl
+++ b/getssl
@@ -762,6 +762,7 @@ if [ ${_CHECK_ALL} -eq 1 ]; then
     if [ -d "$dir" ]; then
       debug "Checking $dir"
       cmd="$0"
+      cmd="$cmd -U"  # No update checks: calling recursively
       if [ ${_USE_DEBUG} -eq 1 ]; then
         cmd="$cmd -d"
       fi


### PR DESCRIPTION
Updates may have optionally been checked for when getssl was run with --all, but the recursive calls for each checked domain should not check for updates at all as doing so is unexpected and/or inefficient.