### PR TITLE
Improve portability

### DIFF
--- a/getssl
+++ b/getssl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ---------------------------------------------------------------------------
 # getssl - Obtain SSL certificates from the letsencrypt.org ACME server
 


### PR DESCRIPTION
Changing the shebang to use env means it'll work on FreeBSD too, where bash lives in /usr/local/bin.