### PR TITLE
Add -Q switch to mute notification about successfull upgrades of getssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ git clone https://github.com/srvrco/getssl.git
 GetSSL was written in standard bash ( so can be run on a server,  a desktop computer, or even a virtualbox) and add the checks, and certificates to a remote server ( providing you have a ssh with key, sftp or ftp access to the remote server).
 
 ```
-getssl ver. 1.00
+getssl ver. 1.48
 Obtain SSL certificates from the letsencrypt.org ACME server
 
-Usage: getssl [-h|--help] [-d|--debug] [-c|--create] [-f|--force] [-a|--all] [-q|--quiet] [-u|--upgrade] [-w working_dir] domain
+Usage: getssl [-h|--help] [-d|--debug] [-c|--create] [-f|--force] [-a|--all] [-q|--quiet] [-Q|--mute] [-u|--upgrade] [-U|--nocheck] [-w working_dir] domain
 
 Options:
   -h, --help      Display this help message and exit
@@ -42,8 +42,10 @@ Options:
   -c, --create    Create default config files
   -f, --force     Force renewal of cert (overrides expiry checks)
   -a, --all       Check all certificates
-  -q, --quiet     Quiet mode (only outputs on error, or succcess of new cert)
-  -u, --upgrade   Upgrade getssl if more recent version available
+  -q, --quiet     Quiet mode (only outputs on error, succcess of new cert, or getssl was upgraded)
+  -Q, --mute      Like -q, but mutes notification about successfull upgrade
+  -u, --upgrade   Upgrade getssl if a more recent version is available
+  -U, --nocheck   Do not check if a more recent version is available
   -w working_dir  Working directory
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/srvrco/getssl.git
 GetSSL was written in standard bash ( so can be run on a server,  a desktop computer, or even a virtualbox) and add the checks, and certificates to a remote server ( providing you have a ssh with key, sftp or ftp access to the remote server).
 
 ```
-getssl ver. 1.48
+getssl ver. 1.49
 Obtain SSL certificates from the letsencrypt.org ACME server
 
 Usage: getssl [-h|--help] [-d|--debug] [-c|--create] [-f|--force] [-a|--all] [-q|--quiet] [-Q|--mute] [-u|--upgrade] [-U|--nocheck] [-w working_dir] domain

--- a/getssl
+++ b/getssl
@@ -142,6 +142,7 @@ _CREATE_CONFIG=0
 _CHECK_ALL=0
 _FORCE_RENEW=0
 _QUIET=0
+_MUTE=0
 _UPGRADE=0
 _UPGRADE_CHECK=1
 
@@ -232,7 +233,9 @@ check_getssl_upgrade() { # check if a more recent version of code is available a
       install "$0" "${0}.v${VERSION}"
       install "$temp_upgrade" "$0"
       rm -f "$temp_upgrade"
-      echo "Updated getssl from v${VERSION} to v${latestversion}"
+      if [ ${_MUTE} -eq 0 ]; then
+        echo "Updated getssl from v${VERSION} to v${latestversion}"
+      fi
       eval "$ORIGCMD"
       graceful_exit
     else
@@ -388,7 +391,8 @@ help_message() { # print out the help message
 	  -c, --create    Create default config files
 	  -f, --force     Force renewal of cert (overrides expiry checks)
 	  -a, --all       Check all certificates
-	  -q, --quiet     Quiet mode (only outputs on error, or succcess of new cert)
+	  -q, --quiet     Quiet mode (only outputs on error, succcess of new cert, or getssl was upgraded)
+	  -Q, --mute      Like -q, but mutes notification about successfull upgrade
 	  -u, --upgrade   Upgrade getssl if a more recent version is available
 	  -U, --nocheck   Do not check if a more recent version is available
 	  -w working_dir  Working directory
@@ -553,7 +557,7 @@ urlbase64() { # urlbase64: base64 encoded string with '+' replaced with '-' and 
 }
 
 usage() { # program usage
-  echo "Usage: $PROGNAME [-h|--help] [-d|--debug] [-c|--create] [-f|--force] [-a|--all] [-q|--quiet] [-u|--upgrade] [-U|--nocheck] [-w working_dir] domain"
+  echo "Usage: $PROGNAME [-h|--help] [-d|--debug] [-c|--create] [-f|--force] [-a|--all] [-q|--quiet] [-Q|--mute] [-u|--upgrade] [-U|--nocheck] [-w working_dir] domain"
 }
 
 write_domain_template() { # write out a template file for a domain.
@@ -695,6 +699,9 @@ while [[ -n $1 ]]; do
      _CHECK_ALL=1 ;;
     -q | --quiet)
      _QUIET=1 ;;
+    -Q | --mute)
+     _QUIET=1
+     _MUTE=1 ;;
     -u | --upgrade)
      _UPGRADE=1 ;;
     -U | --nocheck)

--- a/getssl
+++ b/getssl
@@ -112,10 +112,11 @@
 # 2016-09-24 merged in IPv6 support (1.46)
 # 2016-09-27 added additional debug info issue #119 (1.47)
 # 2016-09-27 removed IPv6 switch in favour of checking both IPv4 and IPv6 (1.48)
+# 2016-09-28 Add -Q, or --mute, switch to mute notifications about successfully upgrading getssl (1.49)
 # ---------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="1.48"
+VERSION="1.49"
 
 # defaults
 CODE_LOCATION="https://raw.githubusercontent.com/srvrco/getssl/master/getssl"


### PR DESCRIPTION
@srvrco please have a look. Additionally to fixing the issue I updated the README.md a little bit to have it match the current version.

## Feature
Fixes #123.
The `-Q` switche now does the same like `-q` with the only difference that `-Q` additionally mutes the 
> Updated getssl from v1.XX to v1.XY

messages.