### PR TITLE
Busybox

### DIFF
--- a/getssl
+++ b/getssl
@@ -1206,30 +1206,32 @@ if [[ "${CHECK_REMOTE}" == "true" ]] && [ $_FORCE_RENEW -eq 0 ]; then
 #          debug "local certificate doesn't exist, saving a copy from remote"
 #          echo "$EX_CERT" > "$DOMAIN_DIR/${DOMAIN}.crt"
 #        fi
-        # check renew-date on ex_cert and compare to local ( if local exists)
-        enddate_ex=$(echo "$EX_CERT" | openssl x509 -noout -enddate 2>/dev/null| cut -d= -f 2-)
-        enddate_lc=$(openssl x509 -noout -enddate < "$CERT_FILE" 2>/dev/null| cut -d= -f 2-)
-        enddate_ex_s=$(date_epoc "$enddate_ex")
-        enddate_lc_s=$(date_epoc "$enddate_lc")
-        debug "external cert has enddate $enddate_ex ( $enddate_ex_s ) "
-        debug "local    cert has enddate $enddate_lc ( $enddate_lc_s ) "
-        if [ "$enddate_ex_s" -eq "$enddate_lc_s" ]; then
-          debug "certificates expire at the same time"
-        elif [ "$enddate_ex_s" -gt "$enddate_lc_s" ]; then
-          # remote has longer to expiry date than local copy.
-          debug "remote cert has longer to run than local cert - ignoring"
-        else
-          info "remote expires sooner than local ..... will attempt to upload from local"
-          copy_file_to_location "domain certificate" "$CERT_FILE" "$DOMAIN_CERT_LOCATION"
-          copy_file_to_location "private key" "$DOMAIN_DIR/${DOMAIN}.key" "$DOMAIN_KEY_LOCATION"
-          copy_file_to_location "CA certificate" "$CA_CERT" "$CA_CERT_LOCATION"
-          cat "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}_chain.pem"
-          copy_file_to_location "full pem" "$TEMP_DIR/${DOMAIN}_chain.pem"  "$DOMAIN_CHAIN_LOCATION"
-          cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
-          copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_k_C.pem"  "$DOMAIN_KEY_CERT_LOCATION"
-          cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
-          copy_file_to_location "full pem" "$TEMP_DIR/${DOMAIN}.pem"  "$DOMAIN_PEM_LOCATION"
-          reload_service
+        if [ -f "$CERT_FILE" ]; then
+          # check renew-date on ex_cert and compare to local ( if local exists)
+          enddate_ex=$(echo "$EX_CERT" | openssl x509 -noout -enddate 2>/dev/null| cut -d= -f 2-)
+          enddate_lc=$(openssl x509 -noout -enddate < "$CERT_FILE" 2>/dev/null| cut -d= -f 2-)
+          enddate_ex_s=$(date_epoc "$enddate_ex")
+          enddate_lc_s=$(date_epoc "$enddate_lc")
+          debug "external cert has enddate $enddate_ex ( $enddate_ex_s ) "
+          debug "local    cert has enddate $enddate_lc ( $enddate_lc_s ) "
+          if [ "$enddate_ex_s" -eq "$enddate_lc_s" ]; then
+            debug "certificates expire at the same time"
+          elif [ "$enddate_ex_s" -gt "$enddate_lc_s" ]; then
+            # remote has longer to expiry date than local copy.
+            debug "remote cert has longer to run than local cert - ignoring"
+          else
+            info "remote expires sooner than local ..... will attempt to upload from local"
+            copy_file_to_location "domain certificate" "$CERT_FILE" "$DOMAIN_CERT_LOCATION"
+            copy_file_to_location "private key" "$DOMAIN_DIR/${DOMAIN}.key" "$DOMAIN_KEY_LOCATION"
+            copy_file_to_location "CA certificate" "$CA_CERT" "$CA_CERT_LOCATION"
+            cat "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}_chain.pem"
+            copy_file_to_location "full pem" "$TEMP_DIR/${DOMAIN}_chain.pem"  "$DOMAIN_CHAIN_LOCATION"
+            cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
+            copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_k_C.pem"  "$DOMAIN_KEY_CERT_LOCATION"
+            cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
+            copy_file_to_location "full pem" "$TEMP_DIR/${DOMAIN}.pem"  "$DOMAIN_PEM_LOCATION"
+            reload_service
+          fi
         fi
       else
         info "Certificate on remote domain does not match domain, ignoring remote certificate"

--- a/getssl
+++ b/getssl
@@ -370,21 +370,26 @@ copy_file_to_location() { # copies a file, using scp if required.
   fi
 }
 
-date_epoc() { # convert the date into epoch time
-  if [[ "$os" == "bsd" ]]; then
-    date -j -f "%b %d %T %Y %Z" "$1" +%s
-  elif [[ "$os" == "mac" ]]; then
-    date -j -f "%b %d %T %Y %Z" "$1" +%s
+date_direpoc() { # convert the dir date into epoch time
+  if [[ "$os" == "bsd" || "$os" == "mac" ]]; then
+    date -j -f "%F %H:%M" "$1" +%s
   else
     date -d "$1" +%s
   fi
+}
 
+date_epoc() { # convert the date into epoch time
+  if [[ "$os" == "bsd" || "$os" == "mac" ]]; then # uses older style date function.
+    date -j -f "%b %d %T %Y %Z" "$1" +%s
+  elif date --version |& grep -iqw busybox; then # BB needs explicit format
+    date -D "%b %d %T %Y %Z" -d "$1" +%s
+  else
+    date -d "$1" +%s
+  fi
 }
 
 date_fmt() { # format date from epoc time to YYYY-MM-DD
-  if [[ "$os" == "bsd" ]]; then #uses older style date function.
-    date -j -f "%s" "$1" +%F
-  elif [[ "$os" == "mac" ]]; then # MAC OSX uses older BSD style date.
+  if [[ "$os" == "bsd" || "$os" == "mac" ]]; then # uses older style date function.
     date -j -f "%s" "$1" +%F
   else
     date -d "@$1" +%F
@@ -392,13 +397,9 @@ date_fmt() { # format date from epoc time to YYYY-MM-DD
 }
 
 date_renew() { # calculates the renewal time in epoch and formatted
-  if [[ "$os" == "bsd" ]]; then
+  if [[ "$os" == "bsd" || "$os" == "mac" ]] || date --version |& grep -iqw busybox; then
     date_now=$(date "+%b %d %T %Y %Z")
-    date_now_s=$( date_epoc "$date_now" )
-    echo "$((date_now_s + RENEW_ALLOW*24*60*60))"
-  elif [[ "$os" == "mac" ]]; then
-    date_now=$(date "+%b %d %T %Y %Z")
-    date_now_s=$( date_epoc "$date_now" )
+    date_now_s=$(date_epoc "$date_now")
     echo "$((date_now_s + RENEW_ALLOW*24*60*60))"
   else
     date -d "${RENEW_ALLOW} days" +%s
@@ -609,13 +610,7 @@ purge_archive() { # purge archive of old, invalid, certificates
     # check each directory
     if [ -d "$padir" ]; then
       tstamp=$(basename "$padir"| awk -F"_" '{print $1"-"$2"-"$3" "$4":"$5}')
-      if [[ "$os" == "bsd" ]]; then
-        direpoc=$(date -j -f "%F %H:%M" "$tstamp" +%s)
-      elif [[ "$os" == "mac" ]]; then
-        direpoc=$(date -j -f "%F %H:%M" "$tstamp" +%s)
-      else
-        direpoc=$(date -d "$tstamp" +%s)
-      fi
+      direpoc=$(date_direpoc "$tstamp")
       current_epoc=$(date "+%s")
       # as certs currently valid for 90 days, purge anything older than 100
       purgedate=$((current_epoc - 60*60*24*100))


### PR DESCRIPTION
Now should be compatible with 'date' applet from BusyBox package:

```
BusyBox v1.25.0 (2016-08-16 19:35:35 CEST) multi-call binary.

Usage: date [OPTIONS] [+FMT] [TIME]

Display time (using +FMT), or set time

        [-s,--set] TIME Set time to TIME
        -u,--utc        Work in UTC (don't convert to local time)
        -R,--rfc-2822   Output RFC-2822 compliant date string
        -I[SPEC]        Output ISO-8601 compliant date string
                        SPEC='date' (default) for date only,
                        'hours', 'minutes', or 'seconds' for date and
                        time to the indicated precision
        -r,--reference FILE     Display last modification time of FILE
        -d,--date TIME  Display TIME, not 'now'
        -D FMT          Use FMT for -d TIME conversion

Recognized TIME formats:
        hh:mm[:ss]
        [YYYY.]MM.DD-hh:mm[:ss]
        YYYY-MM-DD hh:mm[:ss]
        [[[[[YY]YY]MM]DD]hh]mm[.ss]
        'date TIME' form accepts MMDDhhmm[[YY]YY][.ss] instead
```
