### PR TITLE
Replace process substitution with simple pipeline to improve portability

### DIFF
--- a/getssl
+++ b/getssl
@@ -405,8 +405,7 @@ create_csr() { # create a csr using a given key (if it doesn't already exist)
   # if CSR does not exist, or flag set to recreate, then create csr
   if [ ! -f "$csr_file" ] || [ "$_RECREATE_CSR" == "1" ]; then
     info "creating domain csr - $csr_file"
-    openssl req -new -sha256 -key "$csr_key" -subj "/" -reqexts SAN -config \
-    <(cat "$SSLCONF" <(printf "[SAN]\n%s" "$SANLIST")) > "$csr_file"
+    echo -ne "[SAN]\n$SANLIST" | cat "$SSLCONF" - | openssl req -new -sha256 -key "$csr_key" -subj "/" -reqexts SAN -config >"$csr_file"
   fi
 }
 


### PR DESCRIPTION
```
$ bash --version
GNU bash, wersja 4.4.0(1)-release (i586-slackware-linux-gnu)
$ cat /proc/uptime <(echo test)
267749.43 96260.24
test
$ echo test | cat /proc/uptime -
267770.85 96304.53
test
```
but
```
$ bash --version
GNU bash, version 4.3.42(1)-release (mipsel-openwrt-linux-gnu)
$ cat /proc/uptime <(echo test)
-sh: syntax error: unexpected "("
$ echo test | cat /proc/uptime -
230163.34 204618.52
test
```

