### PR TITLE
Cloudflare

### DIFF
--- a/dns_scripts/dns_add_cloudflare
+++ b/dns_scripts/dns_add_cloudflare
@@ -10,17 +10,15 @@ PARAMS=( -H "X-Auth-Email: $email" -H "X-Auth-Key: $key" -H 'Content-Type: appli
 
 # get a list of all domain names from cloudflare
 # If you have a lot, you may need add "&page=1&per_page=1000" and/or "&status=active"
-resp=$(curl --silent "${PARAMS[@]}" -X GET "$API?match=all")
-
-re='"result":\[(([^][]*\[[^][]*])+[^][]*)]' # find result section
+resp=$(curl --silent "${PARAMS[@]}" -X GET "$API")
+re='"result":\[(([^][]*\[[^][]*])*[^][]*)]' # find result section
 [[ "${resp// }" =~ $re ]] && resp="${BASH_REMATCH[1]}"
 while [[ "$resp" ]]; do # iterate through domains returned
-  re='[^}{]*\{(([^}{]*\{[^}{]*})+[^}{]*)}(.*)'
+  re='[^}{]*\{(([^}{]*\{[^}{]*})*[^}{]*)}(.*)'
   [[ "$resp" =~ $re ]]; first="${BASH_REMATCH[1]}"; resp="${BASH_REMATCH[3]}"
 
   # remove subsections - leave only domain level
   while [[ "$first" =~ (.*)[\[\{][^]\{\}[]*[\]\}](.*) ]]; do first="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"; done
-
   re='"name":"([^"]*)"'; [[ "$first" =~ $re ]] && domains=( "${domains[@]}" "${BASH_REMATCH[1]}" )
   re='"id":"([^"]*)"'; [[ "$first" =~ $re ]] && ids=( "${ids[@]}" "${BASH_REMATCH[1]}" )
 done

--- a/dns_scripts/dns_add_cloudflare
+++ b/dns_scripts/dns_add_cloudflare
@@ -1,44 +1,44 @@
 #!/usr/bin/env bash
+# need to add your email address and API key to cloudflare below or set as env variables
+email=${CF_EMAIL:-''}
+key=${CF_KEY:-''}
 
-# need to add your email address and key to cloudflare below
-email=''
-key=''
-
-fulldomain="$1"
-token="$2"
+fulldomain="${1:?Need full domain name as first parameter}"
+token="${2:?Need Let’s Encrypt challenge token as second parameter}"
 API='https://api.cloudflare.com/client/v4/zones'
-AUTH=( -H "X-Auth-Email: $email" -H "X-Auth-Key: $key" -H "Content-Type: application/json" )
+PARAMS=( -H "X-Auth-Email: $email" -H "X-Auth-Key: $key" -H 'Content-Type: application/json' )
 
 # get a list of all domain names from cloudflare
-# If you have a lot, you may need add "&page=1&per_page=1000"
-resp=$(curl --silent "${AUTH[@]}" -X GET "$API?match=all&status=active")
+# If you have a lot, you may need add "&page=1&per_page=1000" and/or "&status=active"
+resp=$(curl --silent "${PARAMS[@]}" -X GET "$API?match=all")
 
-# treat all names with dot as domain names
-while read -d ' ' i; do
-  [[ $i =~ \"name\":\"([^\"]+\.[^\"]+)\" ]] && all_domains="${all_domains:+$all_domains }${BASH_REMATCH[1]}"
-done <<<${resp//[ ,\[\{\}\]]/ }
+re='"result":\[(([^][]*\[[^][]*])+[^][]*)]' # find result section
+[[ "${resp// }" =~ $re ]] && resp="${BASH_REMATCH[1]}"
+while [[ "$resp" ]]; do # iterate through domains returned
+  re='[^}{]*\{(([^}{]*\{[^}{]*})+[^}{]*)}(.*)'
+  [[ "$resp" =~ $re ]]; first="${BASH_REMATCH[1]}"; resp="${BASH_REMATCH[3]}"
 
-[ -z "$all_domains" ] && { echo 'no active domains found on your cloudflare account'; exit 1; }
+  # remove subsections - leave only domain level
+  while [[ "$first" =~ (.*)[\[\{][^]\{\}[]*[\]\}](.*) ]]; do first="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"; done
 
-# select right CF domain (longest one)
+  re='"name":"([^"]*)"'; [[ "$first" =~ $re ]] && domains=( "${domains[@]}" "${BASH_REMATCH[1]}" )
+  re='"id":"([^"]*)"'; [[ "$first" =~ $re ]] && ids=( "${ids[@]}" "${BASH_REMATCH[1]}" )
+done
+
+# select right cloudflare domain (longest one)
 domain=$fulldomain.
-while [[ "$domain" && ! "$all_domains" =~ "${domain%?}" ]]; do domain=${domain#*.}; done
+# shellcheck disable=SC2076
+while [[ "$domain" && ! "${domains[@]/#/@}" == *"@${domain%?}"* ]]; do domain=${domain#*.}; done
 domain=${domain%?}
-
 [ -z "$domain" ] && { echo 'domain name not found on your cloudflare account'; exit 1; }
 
-resp=$(curl --silent "${AUTH[@]}" -X GET "$API?name=$domain&match=any&status=active")
+for i in "${!domains[@]}"; do [[ ${domains[i]} == "$domain" ]] && break; done
+domain_id=${ids[i]}
 
-# select result section
-[[ "$resp" =~ \"result\"[^\{]*\{([^\{\}]*\{[^\{\}]*\}[^\{\}]*)+\} ]]
-resp="${BASH_REMATCH[0]%\}*}"; resp="${resp#*\{}"
-
-# remove subsections - leave only domain level
-while [[ "$resp" =~ (.*)[\[\{][^]\{\}[]*[\]\}](.*) ]]; do resp="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"; done
-
-# must match - we ask for already verified domain
-[[ "${resp// }" =~ \"id\":\"([^\"]+)\" ]]
-domain_id=${BASH_REMATCH[1]}
-
-curl --silent "${AUTH[@]}" -X POST "$API/$domain_id/dns_records" \
-  --data "{\"type\":\"TXT\",\"name\":\"_acme-challenge.${fulldomain%.$domain}\",\"content\":\"$token\",\"ttl\":300}"
+resp=$(curl --silent "${PARAMS[@]}" -X POST "$API/$domain_id/dns_records" \
+  --data "{\"type\":\"TXT\",\"name\":\"_acme-challenge.${fulldomain%.$domain}\",\"content\":\"$token\",\"ttl\":300}")
+# code 81057 = The record already exists.
+if [[ "${resp// }" == *'"success":false'* && ! "${resp// }" == *'"code":81057[^0-9]'* ]]; then
+  re='"message":"([^"]+)"'; [[ "$resp" =~ $re ]]
+  echo "Error: DNS challenge not added: ${BASH_REMATCH[1]:-unknown error}"; exit 2
+fi

--- a/dns_scripts/dns_add_cloudflare
+++ b/dns_scripts/dns_add_cloudflare
@@ -1,43 +1,44 @@
 #!/usr/bin/env bash
 
-email=""
-key=""
+# need to add your email address and key to cloudflare below
+email=''
+key=''
+
 fulldomain="$1"
 token="$2"
+API='https://api.cloudflare.com/client/v4/zones'
+AUTH=( -H "X-Auth-Email: $email" -H "X-Auth-Key: $key" -H "Content-Type: application/json" )
 
-# get a list of all domain names from cloudflare.  If you have a lot, you may need
-# "status=active&page=1&per_page=1000&match=all" instead of just "match=all"
-all_domains=$(curl --silent -X GET "https://api.cloudflare.com/client/v4/zones?match=all" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json" \
-  | grep -o "\"name\":\"[^\"]*\"" | awk -F'"' '{print $4}')
+# get a list of all domain names from cloudflare
+# If you have a lot, you may need add "&page=1&per_page=1000"
+resp=$(curl --silent "${AUTH[@]}" -X GET "$API?match=all&status=active")
 
-NumParts=$(echo "$fulldomain" | awk -F"." '{print NF}')
+# treat all names with dot as domain names
+while read -d ' ' i; do
+  [[ $i =~ \"name\":\"([^\"]+\.[^\"]+)\" ]] && all_domains="${all_domains:+$all_domains }${BASH_REMATCH[1]}"
+done <<<${resp//[ ,\[\{\}\]]/ }
 
-i=1
-while [ $i -lt "$NumParts" ]; do
-  let parts=NumParts-i
-  testpart=$(echo  "$fulldomain" |awk -v n=$parts -F\. '{for (i=n; i<NF; i++) printf $i "."; printf $NF}')
-  res=$(echo "$all_domains" | grep -c "$testpart")
-  if [[ "$res" == "1" ]]; then
-    domain=$(echo "$all_domains" | grep "$testpart")
-    let i=NumParts
-  fi
-  let i=i+1
-done
+[ -z "$all_domains" ] && { echo 'no active domains found on your cloudflare account'; exit 1; }
 
-if [ -z "$domain" ]; then
-  echo "domain name can't be found on your cloudflare account"
-  exit 1
-fi
+# select right CF domain (longest one)
+domain=$fulldomain.
+while [[ "$domain" && ! "$all_domains" =~ "${domain%?}" ]]; do domain=${domain#*.}; done
+domain=${domain%?}
 
-txtname=$( echo "_acme-challenge.${fulldomain}" | sed "s/.${domain}//")
+[ -z "$domain" ] && { echo 'domain name not found on your cloudflare account'; exit 1; }
 
-response=$(curl --silent -X GET "https://api.cloudflare.com/client/v4/zones?name=${domain}&match=all" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json")
+resp=$(curl --silent "${AUTH[@]}" -X GET "$API?name=$domain&match=any&status=active")
 
-domain_section=$(echo "$response" | awk -F"[}]" '{for(i=1;i<=NF;i++){if($i~/\"'"${domain}"'\"/){print $i}}}')
-domain_id=$(echo "$domain_section" | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/\"'"id"'\"/){print $(i+1)}}}'| awk -F'"' '{print $2}')
+# select result section
+[[ "$resp" =~ \"result\"[^\{]*\{([^\{\}]*\{[^\{\}]*\}[^\{\}]*)+\} ]]
+resp="${BASH_REMATCH[0]%\}*}"; resp="${resp#*\{}"
 
-response=$(curl --silent -X POST "https://api.cloudflare.com/client/v4/zones/${domain_id}/dns_records" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json" \
-  --data "{\"type\":\"TXT\",\"name\":\"${txtname}\",\"content\":\"$token\",\"ttl\":300}")
+# remove subsections - leave only domain level
+while [[ "$resp" =~ (.*)[\[\{][^]\{\}[]*[\]\}](.*) ]]; do resp="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"; done
+
+# must match - we ask for already verified domain
+[[ "${resp// }" =~ \"id\":\"([^\"]+)\" ]]
+domain_id=${BASH_REMATCH[1]}
+
+curl --silent "${AUTH[@]}" -X POST "$API/$domain_id/dns_records" \
+  --data "{\"type\":\"TXT\",\"name\":\"_acme-challenge.${fulldomain%.$domain}\",\"content\":\"$token\",\"ttl\":300}"

--- a/dns_scripts/dns_del_cloudflare
+++ b/dns_scripts/dns_del_cloudflare
@@ -1,53 +1,50 @@
 #!/usr/bin/env bash
+# need to add your email address and API key to cloudflare below or set as env variables
+email=${CF_EMAIL:-''}
+key=${CF_KEY:-''}
 
-# need to add your email address and key to cloudflare below
-email=""
-key=""
+fulldomain="${1:?Need full domain name as first parameter}"
+token="$2" # If not set try to remove all tokens for fulldomain
+API='https://api.cloudflare.com/client/v4/zones'
+PARAMS=( -H "X-Auth-Email: $email" -H "X-Auth-Key: $key" -H 'Content-Type: application/json' )
 
-fulldomain="$1"
+# get a list of all domain names from cloudflare
+# If you have a lot, you may need add "&page=1&per_page=1000" and/or "&status=active"
+resp=$(curl --silent "${PARAMS[@]}" -X GET "$API")
+re='"result":\[(([^][]*\[[^][]*])*[^][]*)]' # find result section
+[[ "${resp// }" =~ $re ]] && resp="${BASH_REMATCH[1]}"
+while [[ "$resp" ]]; do # iterate through domains returned
+  re='[^}{]*\{(([^}{]*\{[^}{]*})*[^}{]*)}(.*)'
+  [[ "$resp" =~ $re ]]; first="${BASH_REMATCH[1]}"; resp="${BASH_REMATCH[3]}"
 
-# get a list of all domain names from cloudflare.  If you have a lot, you may need
-# "status=active&page=1&per_page=1000&match=all" instead of just "match=all"
-all_domains=$(curl --silent -X GET "https://api.cloudflare.com/client/v4/zones?match=all" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json" \
-  | grep -o "\"name\":\"[^\"]*\"" | awk -F'"' '{print $4}')
-
-NumParts=$(echo "$fulldomain" | awk -F"." '{print NF}')
-
-i=1
-while [ $i -lt "$NumParts" ]; do
-  let parts=NumParts-i
-  testpart=$(echo  "$fulldomain" |awk -v n=$parts -F\. '{for (i=n; i<NF; i++) printf $i "."; printf $NF}')
-  res=$(echo "$all_domains" | grep -c "$testpart")
-  if [[ "$res" == "1" ]]; then
-    domain=$(echo "$all_domains" | grep "$testpart")
-    let i=NumParts
-  fi
-  let i=i+1
+  # remove subsections - leave only domain level
+  while [[ "$first" =~ (.*)[\[\{][^]\{\}[]*[\]\}](.*) ]]; do first="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"; done
+  re='"name":"([^"]*)"'; [[ "$first" =~ $re ]] && domains=( "${domains[@]}" "${BASH_REMATCH[1]}" )
+  re='"id":"([^"]*)"'; [[ "$first" =~ $re ]] && ids=( "${ids[@]}" "${BASH_REMATCH[1]}" )
 done
 
-if [ -z "$domain" ]; then
-  echo "domain name can't be found on your cloudflare account"
-  exit 1
-fi
+# select right cloudflare domain (longest one)
+domain=$fulldomain.
+# shellcheck disable=SC2076
+while [[ "$domain" && ! "${domains[@]/#/@}" == *"@${domain%?}"* ]]; do domain=${domain#*.}; done
+domain=${domain%?}
+[ -z "$domain" ] && { echo 'domain name not found on your cloudflare account'; exit 1; }
 
-txtname=$( echo "_acme-challenge.${fulldomain}" | sed "s/.${domain}//")
+for i in "${!domains[@]}"; do [[ ${domains[i]} == "$domain" ]] && break; done
+domain_id=${ids[i]}
 
-response=$(curl --silent -X GET "https://api.cloudflare.com/client/v4/zones?name=${domain}&match=all" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json")
+resp=$(curl --silent "${PARAMS[@]}" -X GET "$API/$domain_id/dns_records?type=TXT&name=_acme-challenge.$fulldomain${token:+&content=$token}")
+re='"result":\[(([^][]*\[[^][]*])*[^][]*)]' # find result section
+[[ "${resp// }" =~ $re ]] && resp="${BASH_REMATCH[1]}"
+[ -z "$resp" ] && { echo 'challenge TXT record not found on your cloudflare account'; exit 2; }
 
-domain_section=$(echo "$response" | awk -F"[}]" '{for(i=1;i<=NF;i++){if($i~/\"'"${domain}"'\"/){print $i}}}')
-domain_id=$(echo "$domain_section" | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/\"'"id"'\"/){print $(i+1)}}}'| awk -F'"' '{print $2}')
-
-response=$(curl --silent -X GET "https://api.cloudflare.com/client/v4/zones/${domain_id}/dns_records?type=TXT&name=${txtname}.${domain}" \
--H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json")
-
-zone_ids=$(echo "$response" | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/\"'"id"'\"/){print $(i+1)}}}'| awk -F'"' '{print $2}')
-
-ids=( $zone_ids )
-
-# loop though all IDs ( if more than one )
-for id in "${ids[@]}"; do
-  response=$(curl --silent -X DELETE "https://api.cloudflare.com/client/v4/zones/${domain_id}/dns_records/${id}" \
-  -H "X-Auth-Email: ${email}" -H "X-Auth-Key: ${key}" -H "Content-Type: application/json")
+while [[ "$resp" ]]; do # iterate through records returned
+  re='[^}{]*\{(([^}{]*\{[^}{]*})+[^}{]*)}(.*)'
+  [[ "$resp" =~ $re ]]; first="${BASH_REMATCH[1]}"; resp="${BASH_REMATCH[3]}"
+  re='"id":"([^"]*)"'; [[ "$first" =~ $re ]] && id="${BASH_REMATCH[1]}"
+  respd=$(curl --silent "${PARAMS[@]}" -X DELETE "$API/$domain_id/dns_records/$id")
+  if [[ "${respd// }" == *'"success":false'* ]]; then
+    re='"message":"([^"]+)"'; [[ "$respd" =~ $re ]]
+    echo "Error: DNS challenge not deleted: ${BASH_REMATCH[1]:-unknown error}"; exit 3
+  fi
 done


### PR DESCRIPTION
Reworked DNS Cloudflare scripts:
- removed dependency on external tools (grep, awk, sed), use only pure bash and curl
- allow set auth key from env
- do strict response json structure parsing
- don't query CF twice for the same thing
- add optional parameter to delete only selected ACME token (delete all as default - not changed)
- report errors returned from CF

Tested with:
- GNU bash, version 4.4.0(1)-release (i586-slackware-linux-gnu)
- GNU bash, version 4.3.42(1)-release (mipsel-openwrt-linux-gnu)
- GNU bash, version 4.1.5(1)-release (arm-unknown-linux-gnueabi)
- curl 7.50.3 (i686-pc-linux-gnu) libcurl/7.50.3 OpenSSL/1.0.2j zlib/1.2.8 libidn/1.33 libssh2/1.7.0
- curl 7.49.0 (mipsel-openwrt-linux-gnu) libcurl/7.49.0 OpenSSL/1.0.2h zlib/1.2.8
- curl 7.21.0 (arm-unknown-linux-gnueabi) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.15 libssh2/1.2.6