### PR TITLE
Add Makefile with install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Copyright (c) 2016 Karol Babioch <karol@babioch.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+install:
+
+ifneq ($(strip $(DESTDIR)),)
+	mkdir -p $(DESTDIR)
+endif
+
+	install -Dm755 getssl $(DESTDIR)/usr/bin/getssl
+	
+	install -dm755 $(DESTDIR)/usr/share/getssl
+	cp -r *_scripts $(DESTDIR)/usr/share/getssl
+
+.PHONY: install
+


### PR DESCRIPTION
This adds a simple Makefile which can be used to install the software.
Currently there is only a single install target.