### PR TITLE
Add OCSP Must-Staple

### DIFF
--- a/getssl
+++ b/getssl
@@ -183,10 +183,11 @@
 # 2017-01-29 issue #232 use neutral locale for date formatting (2.07)
 # 2017-01-30 issue #243 compatibility with bash 3.0 (2.08)
 # 2017-01-30 issue #243 additional compatibility with bash 3.0 (2.09)
+# 2017-02-18 add OCSP Must-Staple to the domain csr generation (2.10)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.09"
+VERSION="2.10"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
@@ -218,6 +219,7 @@ REUSE_PRIVATE_KEY="true"
 SERVER_TYPE="https"
 SKIP_HTTP_TOKEN_CHECK="false"
 SSLCONF="$(openssl version -d 2>/dev/null| cut -d\" -f2)/openssl.cnf"
+OCSP_MUST_STAPLE="false"
 TEMP_UPGRADE_FILE=""
 TOKEN_USER_ID=""
 USE_SINGLE_ACL="false"
@@ -620,6 +622,11 @@ create_csr() { # create a csr using a given key (if it doesn't already exist)
     tmp_conf=$(mktemp)
     cat "$SSLCONF" > "$tmp_conf"
     printf "[SAN]\n%s" "$SANLIST" >> "$tmp_conf"
+    # add OCSP Must-Staple to the domain csr
+    # if openssl version >= 1.1.0 one can also use "tlsfeature = status_request"
+    if [[ "$OCSP_MUST_STAPLE" == "true" ]]; then
+      printf "\n1.3.6.1.5.5.7.1.24 = DER:30:03:02:01:05" >> "$tmp_conf"
+    fi
     openssl req -new -sha256 -key "$csr_key" -subj "$CSR_SUBJECT" -reqexts SAN -config "$tmp_conf" > "$csr_file"
     rm -f "$tmp_conf"
   fi


### PR DESCRIPTION
This implements a new variable OCSP_MUST_STAPLE which adds the OCSP Must-Staple detail to the SAN section of the CSR.
If the openssl version is >= 1.1.0, one can also use "tlsfeature = status_request".
See [this blog post](https://scotthelme.co.uk/ocsp-must-staple/) for more details.