### PR TITLE
Initial version of GoDaddy DNS validation support.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Files not to include in .zip/.tar.gz archives
+#
+.git*           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*~
+*#
+*.swp
+*.tmp
+*.bak
+*.tdy
+*.tar.gz
+*.orig
+JSON.sh

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,9 @@ ifneq ($(strip $(DESTDIR)),)
 	mkdir -p $(DESTDIR)
 endif
 
-	install -Dm755 getssl $(DESTDIR)/usr/bin/getssl
-	
-	install -dm755 $(DESTDIR)/usr/share/getssl
-	cp -r *_scripts $(DESTDIR)/usr/share/getssl
+	install -Dvm755 getssl $(DESTDIR)/usr/bin/getssl
+	install -dvm755 $(DESTDIR)/usr/share/getssl
+	for dir in *_scripts; do install -dv $(DESTDIR)/usr/share/getssl/$$dir; install -pv $$dir/* $(DESTDIR)/usr/share/getssl/$$dir/; done
 
 .PHONY: install
 

--- a/dns_scripts/00GoDaddy-README.txt
+++ b/dns_scripts/00GoDaddy-README.txt
@@ -1,0 +1,68 @@
+Using GoDaddy DNS for LetsEncrypt domain validation.
+
+Quick guide to setting up getssl for domain validation of
+GoDaddy DNS domains.
+
+There are two prerequisites to using getssl with GoDaddy DNS:
+
+1) Obtain an API access key from developer.godaddy.com
+   At first sign-up, you will be required to take a "test" key.
+   This is NOT what you need.  Accept it, then get a "Production"
+   key.  At this writing, there is no charge - but you must have
+   a GoDaddy customer account.
+
+   You must get the API key for the account which owns the domain
+   that you want to get certificates for.  If the domains that you
+   manage are owned by more than one account, get a key for each.
+
+   The access key consists of a "Key" and a "Secret".  You need
+   both.
+
+2) Obtain JSON.sh - https://github.com/dominictarr/JSON.sh
+
+With those in hand, the installation procedure is:
+
+1) Create a "myscripts" directory under ~/.getssl/
+
+2) Put JSON.sh in "myscripts"
+
+3) Copy (or softlink from the distribution directory) the
+   following files to "myscripts":
+     dns_godaddy    dns_add_godaddy    dns_del_godaddy
+   None of these files need to be customized.
+
+4) Open your config file (the global file in ~/.getssl/getssl.cfg
+   or the per-account file in ~/.getssl/example.net/getssl.cfg
+
+5) Set the following options:
+   VALIDATE_VIA_DNS="true"
+   DNS_ADD_COMMAND="/path/to/myscripts/dns_add_godaddy"
+   DNS_DEL_COMMAND="/path/to/myscripts/dns_del_godaddy"
+   # The API key for your account/this domain
+   export GODADDY_KEY="..." GODADDY_SECRET="..."
+
+   Note that ~user/ probably won't work in the path.
+
+6) Set any other options that you wish (per the standard
+   directions.)  Use the test CA to make sure that
+   everything is setup correctly.
+
+That's it.  getssl example.net will now validate with DNS.
+
+To trace record additions and removals, run getssl as
+GODADDY_TRACE=Y getssl example.net
+
+There are additional options, which are documented in the
+*godaddy" files and dns_godaddy -h.
+
+Copyright (2017) Timothe Litt  litt at acm _dot org
+
+This sofware may be freely used providing this notice is included with
+all copies.  The name of the author may not be used to endorse
+any other product or derivative work.  No warranty is provided
+and the user assumes all responsibility for use of this software.
+
+Report any issues to https://github.com/tlhackque/getssl/issues.
+
+Enjoy.
+

--- a/dns_scripts/00GoDaddy-README.txt
+++ b/dns_scripts/00GoDaddy-README.txt
@@ -22,28 +22,20 @@ There are two prerequisites to using getssl with GoDaddy DNS:
 
 With those in hand, the installation procedure is:
 
-1) Create a "myscripts" directory under ~/.getssl/
+1) Put JSON.sh in the getssl DNS scripts directory 
+   Default: /usr/share/getssl/dns_scripts
 
-2) Put JSON.sh in "myscripts"
-
-3) Copy (or softlink from the distribution directory) the
-   following files to "myscripts":
-     dns_godaddy    dns_add_godaddy    dns_del_godaddy
-   None of these files need to be customized.
-
-4) Open your config file (the global file in ~/.getssl/getssl.cfg
+2) Open your config file (the global file in ~/.getssl/getssl.cfg
    or the per-account file in ~/.getssl/example.net/getssl.cfg
 
-5) Set the following options:
+3) Set the following options:
    VALIDATE_VIA_DNS="true"
-   DNS_ADD_COMMAND="/path/to/myscripts/dns_add_godaddy"
-   DNS_DEL_COMMAND="/path/to/myscripts/dns_del_godaddy"
+   DNS_ADD_COMMAND="/usr/share/getssl/dns_scripts/dns_add_godaddy"
+   DNS_DEL_COMMAND="/usr/share/getssl/dns_scripts/dns_del_godaddy"
    # The API key for your account/this domain
    export GODADDY_KEY="..." GODADDY_SECRET="..."
 
-   Note that ~user/ probably won't work in the path.
-
-6) Set any other options that you wish (per the standard
+ 4) Set any other options that you wish (per the standard
    directions.)  Use the test CA to make sure that
    everything is setup correctly.
 

--- a/dns_scripts/dns_add_godaddy
+++ b/dns_scripts/dns_add_godaddy
@@ -12,7 +12,8 @@
 #
 # Obtain JSON.sh from https://github.com/dominictarr/JSON.sh
 # Place it in (or softlink it to) the same directory as $GODADDY_SCRIPT,
-# or specify its location with GODADDY_JSON
+# or specify its location with GODADDY_JSON  The default is
+# /usr/share/getssl/dns_scripts/
 #
 # Define GODADDY_KEY and GO_DADDY_SECRET in your account or domain getssl.cfg
 #
@@ -21,7 +22,7 @@
 fulldomain="$1"
 token="$2"
 
-[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="~/.getssl/myscripts/dns_godaddy"
+[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="/usr/share/getssl/dns_scripts/dns_godaddy"
 [[ "$GODADDY_SCRIPT" =~ ^~ ]] && \
     eval 'GODADDY_SCRIPT=`readlink -nf ' $GODADDY_SCRIPT '`'
 

--- a/dns_scripts/dns_add_godaddy
+++ b/dns_scripts/dns_add_godaddy
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (2017) Timothe Litt  litt at acm _dot org
+
+# Add token to GoDaddy dns using dns_godaddy
+
+# You do not have to customize this script.
+#
+# Obtain the Key and Secret from https://developer.godaddy.com/getstarted
+# You must obtain a "Production" key - NOT the "Test" key you're required
+# to get first.
+#
+# Obtain JSON.sh from https://github.com/dominictarr/JSON.sh
+# Place it in (or softlink it to) the same directory as $GODADDY_SCRIPT,
+# or specify its location with GODADDY_JSON
+#
+# Define GODADDY_KEY and GO_DADDY_SECRET in your account or domain getssl.cfg
+#
+# See GoDaddy-README.txt for complete instructions.
+
+fulldomain="$1"
+token="$2"
+
+[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="~/.getssl/myscripts/dns_godaddy"
+[[ "$GODADDY_SCRIPT" =~ ^~ ]] && \
+    eval 'GODADDY_SCRIPT=`readlink -nf ' $GODADDY_SCRIPT '`'
+
+if [ ! -x "$GODADDY_SCRIPT" ]; then
+    echo "$GODADDY_SCRIPT: not found.  Please install, softlink or set GODADDY_SCRIPT to its full path"
+    echo "See GoDaddy-README.txt for complete instructions."
+    exit 3
+fi
+
+# JSON.sh is not (currently) used by add
+
+export GODADDY_KEY
+export GODADDY_SECRET
+
+$GODADDY_SCRIPT -q add ${fulldomain} "_acme-challenge.${fulldomain}." "${token}"

--- a/dns_scripts/dns_add_nsupdate
+++ b/dns_scripts/dns_add_nsupdate
@@ -2,15 +2,38 @@
 
 # example of script to add token to local dns using nsupdate
 
-dnskeyfile="path/to/bla.key"
-
 fulldomain="$1"
 token="$2"
 
-updatefile=$(mktemp)
+# VARIABLES:
+#
+# DNS_NSUPDATE_KEYFILE - path to a TSIG key file, if required
+# DNS_NSUPDATE_GETKEY  - command to execute if access to the key file requires
+#                        some special action: mounting a disk, decrypting a file..
+#                        Called with the operation 'add' and action 'open" / 'close'
 
-printf "update add _acme-challenge.%s. 300 in TXT \"%s\"\n\n" "${fulldomain}" "${token}" > "${updatefile}"
 
-nsupdate -k "${dnskeyfile}" -v "${updatefile}"
+if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'open' ; then
+        exit $(( $? + 128 ))
+    fi
 
-rm -f "${updatefile}"
+    options="-k ${DNS_NSUPDATE_KEYFILE}"
+fi
+
+# Note that blank line is a "send" command to nsupdate
+
+nsupdate ${options} -v <<EOF
+update add  _acme-challenge.${fulldomain}. 300 in TXT "${token}"
+
+EOF
+
+sts=$?
+
+if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'close' ; then
+        exit $(( ${sts} + ( $? * 10 ) ))
+    fi
+fi
+
+exit ${sts}

--- a/dns_scripts/dns_add_nsupdate
+++ b/dns_scripts/dns_add_nsupdate
@@ -14,7 +14,7 @@ token="$2"
 
 
 if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
-    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'open' ; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'open' ${fulldomain} ; then
         exit $(( $? + 128 ))
     fi
 
@@ -31,7 +31,7 @@ EOF
 sts=$?
 
 if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
-    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'close' ; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'add' 'close'  ${fulldomain}; then
         exit $(( ${sts} + ( $? * 10 ) ))
     fi
 fi

--- a/dns_scripts/dns_del_godaddy
+++ b/dns_scripts/dns_del_godaddy
@@ -12,7 +12,8 @@
 #
 # Obtain JSON.sh from https://github.com/dominictarr/JSON.sh
 # Place it in (or softlink it to) the same directory as $GODADDY_SCRIPT,
-# or specify its location with GODADDY_JSON
+# or specify its location with GODADDY_JSON  The default is
+# /usr/share/getssl/dns_scripts/
 #
 # Define GODADDY_KEY and GO_DADDY_SECRET in your account or domain getssl.cfg
 #
@@ -21,7 +22,7 @@
 fulldomain="$1"
 token="$2"
 
-[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="~/.getssl/myscripts/dns_godaddy"
+[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="/usr/share/getssl/dns_scripts/dns_godaddy"
 [[ "$GODADDY_SCRIPT" =~ ^~ ]] && \
     eval 'GODADDY_SCRIPT=`readlink -nf ' $GODADDY_SCRIPT '`'
 

--- a/dns_scripts/dns_del_godaddy
+++ b/dns_scripts/dns_del_godaddy
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright (2017) Timothe Litt  litt at acm _dot org
+
+# Remove token from GoDaddy dns using dns_godaddy
+
+# You do not have to customize this script.
+#
+# Obtain the Key and Secret from https://developer.godaddy.com/getstarted
+# You must obtain a "Production" key - NOT the "Test" key you're required
+# to get first.
+#
+# Obtain JSON.sh from https://github.com/dominictarr/JSON.sh
+# Place it in (or softlink it to) the same directory as $GODADDY_SCRIPT,
+# or specify its location with GODADDY_JSON
+#
+# Define GODADDY_KEY and GO_DADDY_SECRET in your account or domain getssl.cfg
+#
+# See GoDaddy-README.txt for complete instructions.
+
+fulldomain="$1"
+token="$2"
+
+[ -z "$GODADDY_SCRIPT" ] && GODADDY_SCRIPT="~/.getssl/myscripts/dns_godaddy"
+[[ "$GODADDY_SCRIPT" =~ ^~ ]] && \
+    eval 'GODADDY_SCRIPT=`readlink -nf ' $GODADDY_SCRIPT '`'
+
+if ! [ -x "$GODADDY_SCRIPT" ]; then
+    echo "$GODADDY_SCRIPT: not found.  Please install, softlink or set GODADDY_SCRIPT to its full path"
+    echo "See GoDaddy-README.txt for complete instructions."
+    exit 3
+fi
+
+export GODADDY_KEY
+export GODADDY_SECRET
+
+$GODADDY_SCRIPT -q del ${fulldomain} "_acme-challenge.${fulldomain}." "${token}"

--- a/dns_scripts/dns_del_nsupdate
+++ b/dns_scripts/dns_del_nsupdate
@@ -14,7 +14,7 @@ token="$2"
 #                          'open" / 'close'
 
 if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
-    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'open'; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'open' ${fulldomain} ; then
         exit $(( $? + 128 ))
     fi
 
@@ -31,7 +31,7 @@ EOF
 sts=$?
 
 if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
-    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'close' ; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'close'  ${fulldomain} ; then
         exit $(( ${sts} + ( $? * 10 ) ))
     fi
 fi

--- a/dns_scripts/dns_del_nsupdate
+++ b/dns_scripts/dns_del_nsupdate
@@ -1,15 +1,39 @@
 #!/bin/bash
 
-# example of script to add token to local dns using nsupdate
+# example of script to remove token from local dns using nsupdate
 
-dnskeyfile="path/to/bla.key"
 fulldomain="$1"
 token="$2"
 
-updatefile=$(mktemp)
+# VARIABLES:
+#
+# DNS_NSUPDATE_KEYFILE - path to a TSIG key file, if required
+# DNS_NSUPDATE_GETKEY  - command to execute if access to the key file requires
+#                        some special action: dismounting a disk, encrypting a
+#                         file... Called with the operation 'del' and action
+#                          'open" / 'close'
 
-printf "update delete _acme-challenge.%s. 300 in TXT \"%s\"\n\n" "${fulldomain}" "${token}" > "${updatefile}"
+if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'open'; then
+        exit $(( $? + 128 ))
+    fi
 
-nsupdate -k "${dnskeyfile}" -v "${updatefile}"
+    options="-k ${DNS_NSUPDATE_KEYFILE}"
+fi
 
-rm -f "${updatefile}"
+# Note that blank line is a "send" command to nsupdate
+
+nsupdate ${options} -v <<EOF
+update delete  _acme-challenge.${fulldomain}. 300 in TXT "${token}"
+
+EOF
+
+sts=$?
+
+if [ -n "${DNS_NSUPDATE_KEYFILE}" ]; then
+    if [ -n "${DNS_NSUPDATE_KEY_HOOK}" ] && ! ${DNS_NSUPDATE_KEY_HOOK} 'del' 'close' ; then
+        exit $(( ${sts} + ( $? * 10 ) ))
+    fi
+fi
+
+exit ${sts}

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -187,7 +187,7 @@ fi
 authhdr="Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET"
 
 if [ -n "$TRACE" ]; then
-    function timestamp { local tm="`date '+%T:%S%N'`"
+    function timestamp { local tm="`LC_TIME=C date '+%T.%N'`"
         local class="$1"; shift
         echo "${tm:0:15} ** ${class}: $*" >>"$TRACE"
     }

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -1,0 +1,393 @@
+#!/bin/bash
+
+# Copyright (2017) Timothe Litt  litt at acm _dot org
+
+VERSION="1.0.0"
+
+# This script is used to update TXT records in GoDaddy DNS server
+# It depends on JSON.sh from https://github.com/dominictarr/JSON.sh
+# Place it in (or softlink it to) the same directory as this script,
+# or specify its location with GODADDY_JSON
+#
+# See the usage text below, 00GoDaddy-README.txt, dns_add_godaddy
+# and dns_del_godaddy for additional information.
+#
+# It may be freely used providing this notice is included with
+# all copies.  The name of the author may not be used to endorse
+# any other product or derivative work.  No warranty is provided
+# and the user assumes all responsibility for use of this software.
+#
+# Bug reports are welcome at https://github.com/tlhackque/getssl/issues.
+
+API='https://api.godaddy.com/v1/domains'
+APISIGNUP='https://developer.godaddy.com/getstarted'
+GETJSON='https://github.com/dominictarr/JSON.sh'
+
+VERB="y"
+DEBUG="$GODADDY_DEBUG"
+[ -z "$JSON" ] && JSON="$GODADDY_JSON"
+[ -z "$JSON" ] && JSON="`dirname $0`/JSON.sh"
+
+while getopts 'dhj:k:s:qv' opt; do
+    case $opt in
+        d) DEBUG="Y"                                   ;;
+        j) JSON="$OPTARG"                              ;;
+        k) GODADDY_KEY="$OPTARG"                       ;;
+        s) GODADDY_SECRET="$OPTARG"                    ;;
+        q) VERB=                                       ;;
+        v) echo "dns_godaddy version $VERSION"; exit 0 ;;
+        *)
+            cat <<EOF
+Usage
+    `basename $0` [-d -h -j JSON -k:KEY -s:SECRET -q] add domain name data [ttl]
+    `basename $0` [-d -h -j JSON -k:KEY -s:SECRET -q] del domain name data
+
+Add or delete TXT records from GoDaddy DNS
+
+Obtain the Key and Secret from $APISIGNUP
+You must obtain a "Production" key - NOT the "Test" key you're required
+to get first.
+
+With getssl, this script is called from the dns_add_godaddy and
+dns_del_godaddy wrapper scripts.
+
+Arguments:
+    add - add the specified record to the domain
+
+    del - remove the specified record from the domain
+
+    domain is the domain name, e.g. example.org
+
+    name is the DNS record name to add, e.g. _acme-challenge.example.org.
+         Note that trailing '.' is significant in DNS.
+
+    data is the record data, e.g. "myverificationtoken"
+
+    ttl is optional, and defaults to the GoDaddy minimum of 600.
+
+    If it is necessary to turn on debugging externally, define
+    GODADDY_DEBUG="y" (any non-null string will do).
+    For minimal trace output (to override -q), define GODADDY_TRACE="y".
+
+Options
+    -d    Provide debugging output - all requests and responses
+    -h    This help.
+    -j:   Location of JSON.sh Default `dirname $0`/JSON.sh, or
+          the GODADDY_JSON variable.
+    -k:   The GoDaddy API key    Default from GODADDY_KEY
+    -s:   The GoDaddy API secret Default from GODADDY_SECRET
+    -q    Quiet - omit normal success messages,
+
+    All ourput, except for this help text, is to stderr.
+
+Environment variables
+    GODADDY_JSON    location of the JSOH.sh script
+    GODADDY_KEY     default API key
+    GODADDY_SCRIPT  location of this script, default location of JSON.sh
+    GODADDY_SECRET  default API secret
+    GODADDY_TRACE   forces -q off if true
+
+BUGS
+    Due to a limitation of the gOdADDY API, deleting the last TXT record
+    would be too risky for my taste.  So in that case, I replace it with
+    _dummy.record_.domain.  TXT "Ihis record is not used".  This record is
+    not automatically deleted by this script, though it's perfectly OK to
+    do so manually. (Via another mechanism, or if it's no longer the last.)
+
+    This really shouldn't happen often, since most domains have at least
+    one TXT record - for SPF, tracking APIs, etc.
+
+    Report any issues to https://github.com/tlhackque/getssl/issues
+EOF
+            exit 0
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Check for JSON -- required for delete, but if records are added,
+# we assume they'll be deleted later & don't want to strand them.
+
+[[ "$JSON" =~ ^~ ]] && \
+    eval 'JSON=`readlink -nf ' $JSON '`'
+if [ ! -x "$JSON" ]; then
+    cat <<EOF >&2
+$0: requires JSON.sh as "$JSON"
+
+The full path to JSON.sh can be specified with -j, or the
+GODADDY_JSON environment variable.
+
+You can obtain a copy from $GETJSON
+
+Then place or softlink it to $JSON or set GODADDY_JSON.
+EOF
+    exit 2
+fi
+
+if [ -z "$GODADDY_KEY" ] || [ -z "$GODADDY_SECRET" ]; then
+    echo "GODADDY_KEY and GODADDY secret must be defined" >&2
+    exit 3
+fi
+
+[ -n "$DEBUG" ] && VERB="y"
+[ -n "$GODADDY_TRACE" ] && VERB="Y"
+
+# Get parameters & validate
+
+op="$1"
+if ! [[ "$op" =~ ^(add|del)$ ]]; then
+    echo "Operation must be \"add\" or \"del\"" >&2
+    exit 3
+fi
+domain="$2"
+domain="${domain%'.'}"
+if [ -z "$domain" ]; then
+    echo "'domain' parameter is required, see -h" >&2
+    exit 3
+fi
+name="$3"
+if [ -z "$name" ]; then
+    echo "'name' parameter is required, see -h" >&2
+    exit 3
+fi
+! [[ "$name" =~ [.]$ ]] && name="${name}.${domain}."
+data="$4"
+if [ -z "$data" ]; then
+    echo "'data' parameter is required, see -h" >&2
+    exit 3
+fi
+
+if [ "$op" = 'del' ]; then
+    ttl=
+elif [ -z "$5" ]; then
+    ttl="600"  # GoDaddy minimum TTL is 600
+elif ! [[ "$5" =~ ^[0-9]+$ ]]; then
+    echo "TTL $5 is not numeric" >&2
+    exit 3
+elif [ $5 -lt 600 ]; then
+    [ -n "$VERB" ] && \
+        echo "$5 is less than GoDaddy minimum of 600; increased to 600" >&2
+    ttl="600"
+else
+    ttl="$5"
+fi
+
+# --- Done with parameters
+
+[ -n "$DEBUG" ] && \
+    echo "`basename $0`: $op $domain $name \"$data\" $ttl" >&2
+
+# Authorization header has secret and key
+# N.B. These will appear in a 'ps' listing since curl only allows
+#      headers to be provided on the command line.
+
+authhdr="Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET"
+
+[ -n "$DEBUG" ] &&  echo "$authhdr" >&2
+
+if [ "$op" = "add" ]; then
+    # May need to retry due to zone cuts
+
+    while [[ "$domain" =~ [^.]+\.[^.]+ ]]; do
+
+        url="$API/$domain/records/TXT/$name"
+
+        request='{"data":"'$data'","ttl":'$ttl'}'
+        [ -n "$DEBUG" ] && cat >&2 <<EOF
+Add request to: $url
+--------
+$request"
+--------
+EOF
+        result="$(curl -i -s -X PUT -H "$authhdr" \
+                                    -H "Content-Type: application/json" \
+                       -d "$request" "$url")"
+        sts=$?
+        [ -n "$DEBUG" ] && cat >&2 <<EOF
+
+Result:
+curl status = $sts
+--------
+$result
+--------
+EOF
+        if [ $sts -ne 0 ]; then
+            echo "curl error $sts adding record" >&2
+            exit $sts
+        fi
+        if ! echo "$result" | grep -q '^HTTP/.* 200 '; then
+            code="`echo "$result" | grep '"code":' | sed -e's/^.*"code":"//; s/\".*$//'`"
+            msg="`echo "$result" | grep '"message":' | sed -e's/^.*"message":"//; s/\".*$//'`"
+            if [ "$code" = "DUPLICATE_RECORD" ]; then
+                if [ -n "$VERB" ]; then
+                    echo "$msg in $domain" >&2
+                fi
+                exit 0 # Duplicate record is still success
+            fi
+            if [ "$code" = 'UNKNOWN_DOMAIN' ]; then
+                if [[ "$domain" =~ ^([^.]+)\.([^.]+\.[^.]+.*) ]]; then
+                    [ -n "$DEBUG" ] && \
+                        echo "$domain unknown, trying ${BASH_REMATCH[2]}" >&2
+                    domain="${BASH_REMATCH[2]}"
+                    continue;
+                fi
+            fi
+            echo "Request failed $msg" >&2
+            exit 1
+        fi
+        [ -n "$VERB" ] && echo "$domain: added $name $ttl TXT \"$data\"" >&2
+        exit 0
+    done
+fi
+
+
+# ----- Delete
+
+# There is no delete API
+# But, it is possible to replace all TXT records.
+#
+# So, first query for all TXT records
+
+# May need to retry due to zone cuts
+
+while [[ "$domain" =~ [^.]+\.[^.]+ ]]; do
+
+    url="$API/$domain/records/TXT"
+    [ -n "$DEBUG" ] && echo "Query for TXT records to: $url" >&2
+
+    current="$(curl -i -s -X GET -H "$authhdr" "$url")"
+    sts=$?
+    if [ $sts -ne 0 ]; then
+        echo "curl error $sts for query" >&2
+        exit $sts
+    fi
+    [ -n "$DEBUG" ] && cat >&2 <<EOF
+
+Response
+--------
+$current
+--------
+EOF
+    if ! echo "$current" | grep -q '^HTTP/.* 200 '; then
+        code="`echo "$current" | grep '"code":' | sed -e's/^.*"code":"//; s/\".*$//'`"
+        msg="`echo "$current" | grep '"message":' | sed -e's/^.*"message":"//; s/\".*$//'`"
+        if [ "$code" = "UNKNOWN_DOMAIN" ]; then
+            if [[ "$domain" =~ ^([^.]+)\.([^.]+\.[^.]+.*) ]]; then
+                [ -n "$DEBUG" ] && echo \
+                     "$domain unknown, trying ${BASH_REMATCH[2]}" >&2
+                domain="${BASH_REMATCH[2]}"
+                continue;
+            fi
+        fi
+        echo "Request failed $msg" >&2
+        exit 1
+    fi
+    # Remove headers
+
+    current="$(echo "$current" | sed -e'0,/^\r*$/d')"
+    break
+done
+
+    # The zone cut is known, so the replace can't fail due to UNKNOWN domain
+
+if [ "$current" = '[]' ]; then # No TXT records in zone
+    [ -n "$VERB" ] && echo "$domain: $name TXT \"$data\" does not exist" >&2
+    [ -n "$DEBUG" ] && echo "No TXT records in $domain" >&2
+    exit 1  # Intent was to change, so error status
+fi
+
+[ -n "$DEBUG" ] && echo "Response is valid"
+
+# Prepare request to replace TXT RRSET
+
+# Parse JSON and select only the record structures, which are [index] { ...}
+
+current="$(echo "$current" | $JSON | sed -n -e'/^\[[0-9][0-9]*\]/{ s/^\[[0-9][0-9]*\]//; p}')"
+base="$current"
+
+[ -n "$DEBUG" ] && cat >&2 <<EOF
+Old TXT RRSET:
+$current
+EOF
+
+# Remove the desired record.  The name must be relative.
+
+eval 'name="$''{name%'"'.$domain.'}"'"'
+
+match="$(printf '"name":"%s","data":"%s","ttl":' "$name" "$data")"
+cmd="$(printf 'echo %s%s%s | grep -v %s%s%s' "'" "$current" "'" "'" "$match" "'")"
+eval 'new="$('"$cmd"')"'
+
+if [ "$new" = "$base" ]; then
+    [ -n "$VERB" ] && echo "$domain: $name TXT \"$data\" does not exist" >&2
+    exit 1 # Intent was to change DNS, so this is an error
+fi
+
+# Remove whitespace and insert needed commmas
+#
+fmtnew="$new"
+new=$(echo "$new" | sed -e"s/}/},/g; \$s/},/}/;" | tr -d '\t\n')
+
+if [ -z "$new" ]; then
+    [ -n "$VERB" ] && echo "Replacing last TXT record with a dummy (see -h)" >&2
+    new='{"type":"TXT","name":"_dummy.record_","data":"_This record is not used_","ttl":601}'
+    dummy="t"
+    TAB=$'\t'
+    fmtnew="${TAB}$new"
+    if [ "$fmtnew" = "$base" ]; then
+        [ -n "$VERB" ] && echo "This tool can't delete a placeholder when it is the only TXT record" >&2
+        exit 0 # Not really success, but retrying won't help.
+    fi
+fi
+
+request="[$new]"
+
+[ -n "$DEBUG" ] && cat >&2 <<EOF
+New TXT RRSET will be
+$fmtnew
+
+EOF
+
+url="$API/$domain/records/TXT"
+
+[ -n "$DEBUG" ] && cat >&2 <<EOF
+Replace (delete) request to: $url
+--------
+$request
+--------
+EOF
+
+result="$(curl -i -s -X PUT -H "$authhdr" \
+                            -H "Content-Type: application/json" \
+               -d "$request" "$url")"
+sts=$?
+[ -n "$DEBUG" ] && cat >&2 <<EOF
+
+Result:
+curl status = $sts
+--------
+$result
+--------
+EOF
+
+if [ $sts -ne 0 ]; then
+    echo "curl error $sts deleting record" >&2
+    exit $sts
+fi
+if ! echo "$result" | grep -q '^HTTP/.* 200 '; then
+    result="$(echo "$result" | sed -e'0,/^\r*$/d')"
+    code="`echo "$result" | grep '"code":' | sed -e's/^.*"code":"//; s/\".*$//'`"
+    msg="`echo "$result" | grep '"message":' | sed -e's/^.*"message":"//; s/\".*$//'`"
+    echo "Request failed $msg" >&2
+    exit 1
+fi
+
+if [ -n "$VERB" ]; then
+    if [ -n "$dummy" ]; then
+        echo "$domain: replaced $name TXT \"$data\" with a placeholder" >&2
+    else
+        echo "$domain: deleted $name TXT \"$data\"" >&2
+    fi
+fi
+exit 0
+

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -2,7 +2,8 @@
 
 # Copyright (2017) Timothe Litt  litt at acm _dot org
 
-VERSION="1.0.0"
+VERSION="1.0.1"
+PROG="`basename $0`"
 
 # This script is used to update TXT records in GoDaddy DNS server
 # It depends on JSON.sh from https://github.com/dominictarr/JSON.sh
@@ -28,19 +29,20 @@ DEBUG="$GODADDY_DEBUG"
 [ -z "$JSON" ] && JSON="$GODADDY_JSON"
 [ -z "$JSON" ] && JSON="`dirname $0`/JSON.sh"
 
-while getopts 'dhj:k:s:qv' opt; do
+while getopts 'dhj:k:s:t:qv' opt; do
     case $opt in
         d) DEBUG="Y"                                   ;;
         j) JSON="$OPTARG"                              ;;
         k) GODADDY_KEY="$OPTARG"                       ;;
         s) GODADDY_SECRET="$OPTARG"                    ;;
+        t) TRACE="$OPTARG"                             ;;
         q) VERB=                                       ;;
         v) echo "dns_godaddy version $VERSION"; exit 0 ;;
         *)
             cat <<EOF
 Usage
-    `basename $0` [-d -h -j JSON -k:KEY -s:SECRET -q] add domain name data [ttl]
-    `basename $0` [-d -h -j JSON -k:KEY -s:SECRET -q] del domain name data
+    $PROG [-dt -h -j JSON -k:KEY -s:SECRET -q] add domain name data [ttl]
+    $PROG [-dt -h -j JSON -k:KEY -s:SECRET -q] del domain name data
 
 Add or delete TXT records from GoDaddy DNS
 
@@ -76,9 +78,10 @@ Options
           the GODADDY_JSON variable.
     -k:   The GoDaddy API key    Default from GODADDY_KEY
     -s:   The GoDaddy API secret Default from GODADDY_SECRET
+    -t:   Detailed protocol trace data is appended to specified file
     -q    Quiet - omit normal success messages,
 
-    All ourput, except for this help text, is to stderr.
+    All output, except for this help text, is to stderr.
 
 Environment variables
     GODADDY_JSON    location of the JSOH.sh script
@@ -86,6 +89,7 @@ Environment variables
     GODADDY_SCRIPT  location of this script, default location of JSON.sh
     GODADDY_SECRET  default API secret
     GODADDY_TRACE   forces -q off if true
+    GODADDY_TFILE   appends protocol trace to file. Overrides -t
 
 BUGS
     Due to a limitation of the gOdADDY API, deleting the last TXT record
@@ -131,6 +135,7 @@ fi
 
 [ -n "$DEBUG" ] && VERB="y"
 [ -n "$GODADDY_TRACE" ] && VERB="Y"
+[ -n "$GODADDY_TFILE" ] && TRACE="$GODADDY_TFILE"
 
 # Get parameters & validate
 
@@ -175,11 +180,24 @@ fi
 # --- Done with parameters
 
 [ -n "$DEBUG" ] && \
-    echo "`basename $0`: $op $domain $name \"$data\" $ttl" >&2
+    echo "$PROG: $op $domain $name \"$data\" $ttl" >&2
 
 # Authorization header has secret and key
 
 authhdr="Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET"
+
+if [ -n "$TRACE" ]; then
+    function timestamp { local tm="`date '+%T:%S%N'`"
+        local class="$1"; shift
+        echo "${tm:0:15} ** ${class}: $*" >>"$TRACE"
+    }
+    timestamp 'Info' "$PROG" "V$VERSION" 'Starting new protocol trace'
+    timestamp 'Args' "$@"
+    function curl {
+        command curl --trace-time --trace-ascii % "$@" 2>>"$TRACE"
+    }
+    [ -n "$VERB" ] && echo "Appending protocol trace to $TRACE"
+fi
 
 [ -n "$DEBUG" ] &&  echo "$authhdr" >&2
 

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -193,8 +193,9 @@ if [ -n "$TRACE" ]; then
     }
     timestamp 'Info' "$PROG" "V$VERSION" 'Starting new protocol trace'
     timestamp 'Args' "$@"
+    curl --help | grep -q -- --trace-time && CURL_TFLAGS="--trace-time" # 7.14.0
     function curl {
-        command curl --trace-time --trace-ascii % "$@" 2>>"$TRACE"
+        command curl ${CURL_TFLAGS} --trace-ascii % "$@" 2>>"$TRACE"
     }
     [ -n "$VERB" ] && echo "Appending protocol trace to $TRACE"
 fi

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -178,8 +178,6 @@ fi
     echo "`basename $0`: $op $domain $name \"$data\" $ttl" >&2
 
 # Authorization header has secret and key
-# N.B. These will appear in a 'ps' listing since curl only allows
-#      headers to be provided on the command line.
 
 authhdr="Authorization: sso-key $GODADDY_KEY:$GODADDY_SECRET"
 
@@ -199,9 +197,12 @@ Add request to: $url
 $request"
 --------
 EOF
-        result="$(curl -i -s -X PUT -H "$authhdr" \
-                                    -H "Content-Type: application/json" \
-                       -d "$request" "$url")"
+
+        result="$(curl -i -s -X PUT -d "$request" --config - "$url" <<EOF
+                       header = "Content-Type: application/json" 
+                       header = "$authhdr"
+EOF
+)"
         sts=$?
         [ -n "$DEBUG" ] && cat >&2 <<EOF
 
@@ -255,7 +256,10 @@ while [[ "$domain" =~ [^.]+\.[^.]+ ]]; do
     url="$API/$domain/records/TXT"
     [ -n "$DEBUG" ] && echo "Query for TXT records to: $url" >&2
 
-    current="$(curl -i -s -X GET -H "$authhdr" "$url")"
+    current="$(curl -i -s -X GET --config - "$url" <<EOF
+                        header = "$authhdr" 
+EOF
+)"
     sts=$?
     if [ $sts -ne 0 ]; then
         echo "curl error $sts for query" >&2
@@ -357,9 +361,11 @@ $request
 --------
 EOF
 
-result="$(curl -i -s -X PUT -H "$authhdr" \
-                            -H "Content-Type: application/json" \
-               -d "$request" "$url")"
+result="$(curl -i -s -X PUT -d  "$request" --config - "$url" <<EOF
+               header = "Content-Type: application/json"
+               header = "$authhdr"
+EOF
+)"
 sts=$?
 [ -n "$DEBUG" ] && cat >&2 <<EOF
 

--- a/getssl
+++ b/getssl
@@ -336,7 +336,7 @@ check_config() { # check the config files for all obvious errors
     rsa|prime256v1|secp384r1|secp521r1)
       debug "checked PRIVATE_KEY_ALG " ;;
     *)
-      info "${DOMAIN}: invalid PRIVATE_KEY_ALG - $PRIVATE_KEY_ALG"
+      info "${DOMAIN}: invalid PRIVATE_KEY_ALG - '$PRIVATE_KEY_ALG'"
       config_errors=true ;;
   esac
   if [[ "$DUAL_RSA_ECDSA" == "true" ]] && [[ "$PRIVATE_KEY_ALG" == "rsa" ]]; then

--- a/getssl
+++ b/getssl
@@ -814,7 +814,7 @@ get_certificate() { # get certificate for csr, if all domains validated.
     echo -----BEGIN CERTIFICATE----- > "$gc_certfile"
     curl --silent "$CertData" | openssl base64 -e  >> "$gc_certfile"
     echo -----END CERTIFICATE-----  >> "$gc_certfile"
-    info "Certificate saved in $CERT_FILE"
+    info "Certificate saved in $gc_certfile"
   fi
 
   # If certificate wasn't a valid certificate, error exit.

--- a/getssl
+++ b/getssl
@@ -192,16 +192,20 @@ VERSION="2.10"
 # defaults
 ACCOUNT_KEY_LENGTH=4096
 ACCOUNT_KEY_TYPE="rsa"
+export AUTH_DNS_SERVER=""
 CA="https://acme-staging.api.letsencrypt.org"
 CA_CERT_LOCATION=""
 CHALLENGE_CHECK_TYPE="http"
 CHECK_ALL_AUTH_DNS="false"
+CHECK_CERT_TIMEOUT="4"
 CHECK_REMOTE="true"
 CHECK_REMOTE_WAIT=0
 CODE_LOCATION="https://raw.githubusercontent.com/srvrco/getssl/master/getssl"
 CSR_SUBJECT="/"
 DEACTIVATE_AUTH="false"
 DEFAULT_REVOKE_CA="https://acme-v01.api.letsencrypt.org"
+DNS_CHECK_FUNC=""
+DNS_CHECK_OPTIONS=""
 DNS_EXTRA_WAIT=""
 DNS_WAIT=10
 DOMAIN_KEY_LENGTH=4096
@@ -212,7 +216,7 @@ IGNORE_DIRECTORY_DOMAIN="false"
 ORIG_UMASK=$(umask)
 PREVIOUSLY_VALIDATED="true"
 PRIVATE_KEY_ALG="rsa"
-PUBLIC_DNS_SERVER=""
+export PUBLIC_DNS_SERVER=""
 RELOAD_CMD=""
 RENEW_ALLOW="30"
 REUSE_PRIVATE_KEY="true"
@@ -389,14 +393,14 @@ check_config() { # check the config files for all obvious errors
         config_errors=true
       fi
       # check domain exist
-      if [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
+      if [[ "$DNS_CHECK_FUNC" =~ ^drill ]] || [[ "$DNS_CHECK_FUNC" =~ ^dig ]]; then
         if [[ "$($DNS_CHECK_FUNC "${d}" SOA|grep -c "^${d}")" -ge 1 ]]; then
           debug "found IP for ${d}"
         else
           info "${DOMAIN}: DNS lookup failed for ${d}"
           config_errors=true
         fi
-      elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
+      elif [[ "$DNS_CHECK_FUNC" =~ ^host ]]; then
         if [[ "$($DNS_CHECK_FUNC "${d}" |grep -c "^${d}")" -ge 1 ]]; then
           debug "found IP for ${d}"
         else
@@ -716,20 +720,19 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
     primary_ns="$all_auth_dns_servers"
     return
   fi
-
-  if [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
+  if [[ "$DNS_CHECK_FUNC" =~ ^drill ]] || [[ "$DNS_CHECK_FUNC" =~ ^dig ]]; then
     if [[ -z "$gad_s" ]]; then #checking for CNAMEs
-      res=$($DNS_CHECK_FUNC CNAME "$gad_d"| grep "^$gad_d")
+      res=$($DNS_CHECK_FUNC "$gad_d" CNAME| grep "^$gad_d")
     else
-      res=$($DNS_CHECK_FUNC CNAME "$gad_d" "@$gad_s"| grep "^$gad_d")
+      res=$($DNS_CHECK_FUNC "$gad_d" CNAME "@$gad_s"| grep "^$gad_d")
     fi
     if [[ ! -z "$res" ]]; then # domain is a CNAME so get main domain
       gad_d=$(echo "$res"| awk '{print $5}' |sed 's/\.$//g')
     fi
     if [[ -z "$gad_s" ]]; then #checking for CNAMEs
-      res=$($DNS_CHECK_FUNC NS "$gad_d"| grep "^$gad_d")
+      res=$($DNS_CHECK_FUNC "$gad_d" NS| grep "^$gad_d")
     else
-      res=$($DNS_CHECK_FUNC NS "$gad_d" "@$gad_s"| grep "^$gad_d")
+      res=$($DNS_CHECK_FUNC "$gad_d" NS "@$gad_s"| grep "^$gad_d")
     fi
     if [[ -z "$res" ]]; then
       error_exit "couldn't find primary DNS server - please set AUTH_DNS_SERVER in config"
@@ -744,7 +747,7 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
     return
   fi
 
-  if [[ "$DNS_CHECK_FUNC" == "host" ]]; then
+  if [[ "$DNS_CHECK_FUNC" =~ ^host ]]; then
     if [[ -z "$gad_s" ]]; then
       res=$($DNS_CHECK_FUNC -t NS "$gad_d"| grep "name server")
     else
@@ -1178,6 +1181,7 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
       response=$($CURL -X POST --data "$body" "$url")
     fi
 
+    touch "$CURL_HEADER"
     responseHeaders=$(cat "$CURL_HEADER")
     debug responseHeaders "$responseHeaders"
     debug response  "$response"
@@ -1325,6 +1329,21 @@ write_domain_template() { # write out a template file for a domain.
 	# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
 	#SERVER_TYPE="https"
 	#CHECK_REMOTE="true"
+
+        # Unusual configurations (especially split views) may require these.
+        # If these (or any variable) apply to all your domains, put them in
+        # the per-domain getssl.cfg.
+        #
+        # If you must use an external DNS Server (e.g. due to split views)
+        # Specify it here.  Otherwise, the default is to find the zone master.
+        # The default will usually work.
+        # PUBLIC_DNS_SERVER="8.8.8.8"
+
+        # If getssl is unable to determine the authoritative nameserver for a domain
+        # it will as you to enter AUTH_DNS_SERVER.  This is the primary  server that
+        # getssl will use to check for the acme tokens.  It must be visible externally
+        # as well as internally.  It need not be "authoritiative" in the RFC1035 sense.
+        # AUTH_DNS_SERVER="8.8.8.8"
 	_EOF_domain_
 }
 
@@ -1364,6 +1383,19 @@ write_getssl_template() { # write out the main template file
 	#VALIDATE_VIA_DNS="true"
 	#DNS_ADD_COMMAND=
 	#DNS_DEL_COMMAND=
+
+        # Unusual configurations (especially split views) may require these.
+        # If you have a mixture, these can go in the per-domain getssl.cfg.
+        #
+        # If you must use an external DNS Server (e.g. due to split views)
+        # Specify it here.  Otherwise, the default is to find the zone master.
+        # The default will usually work.
+        # PUBLIC_DNS_SERVER="8.8.8.8"
+
+        # If getssl is unable to determine the authoritative nameserver for a domain
+        # it will as you to enter AUTH_DNS_SERVER.  This is a server that
+        # can answer queries for the zone - a master or a slave, not a recursive server.
+        # AUTH_DNS_SERVER="10.0.0.14"
 	_EOF_getssl_
 }
 
@@ -1446,7 +1478,6 @@ get_os
 requires which
 requires openssl
 requires curl
-requires nslookup drill dig host DNS_CHECK_FUNC
 requires awk
 requires tr
 requires date
@@ -1495,6 +1526,12 @@ if [[ -s "$WORKING_DIR/getssl.cfg" ]]; then
   debug "reading config from $WORKING_DIR/getssl.cfg"
   # shellcheck source=/dev/null
   . "$WORKING_DIR/getssl.cfg"
+fi
+
+if [[ -n "$DNS_CHECK_FUNC" ]]; then
+  requires "${DNS_CHECK_FUNC}"
+else
+  requires nslookup drill dig host DNS_CHECK_FUNC
 fi
 
 # Define defaults for variables not set in the main config.
@@ -1569,11 +1606,17 @@ if [[ ${_CREATE_CONFIG} -eq 1 ]]; then
   if [[ -s "$DOMAIN_DIR/getssl.cfg" ]]; then
     info "domain config already exists $DOMAIN_DIR/getssl.cfg"
   else
-    info "creating domain config file in $DOMAIN_DIR/getssl.cfg"
-    # if domain has an existing cert, copy from domain and use to create defaults.
-    EX_CERT=$(echo \
-      | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:443" 2>/dev/null \
-      | openssl x509 2>/dev/null)
+      info "Contacting ${DOMAIN} to inspect current certificate"
+      EX_CERT=$( {
+        if [[ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge 43 ]]; then
+          openssl s_client -servername "$DOMAIN" -connect "$DOMAIN":443 </dev/null 2>/dev/null & PID=$!
+          sleep ${CHECK_CERT_TIMEOUT} & PIDW=$!
+          wait -n # Requires bash 4.3+
+          kill -9 "$PID" "$PIDW" 2>/dev/null
+        else
+          openssl s_client -servername "$DOMAIN" -connect "$DOMAIN":443 </dev/null 2>/dev/null
+        fi
+      } | openssl x509 2>/dev/null)
     EX_SANS="www.${DOMAIN}"
     if [[ ! -z "${EX_CERT}" ]]; then
       EX_SANS=$(echo "$EX_CERT" \
@@ -1582,6 +1625,7 @@ if [[ ${_CREATE_CONFIG} -eq 1 ]]; then
       EX_SANS=${EX_SANS//$'\n'/','}
     fi
     write_domain_template "$DOMAIN_DIR/getssl.cfg"
+    info "created domain config file in $DOMAIN_DIR/getssl.cfg"
   fi
   TEMP_DIR="$DOMAIN_DIR/tmp"
   # end of "-c|--create" option, so exit
@@ -1609,6 +1653,11 @@ if [[ -s "$DOMAIN_DIR/getssl.cfg" ]]; then
   . "$DOMAIN_DIR/getssl.cfg"
 fi
 
+# In case special options are needed for DNS_CHECK_FUNC, add them
+# to the command.  E.G. if a TSIG key or bound local IP is required...
+
+DNS_CHECK_FUNC="${DNS_CHECK_FUNC} ${DNS_CHECK_OPTIONS}"
+
 # from SERVER_TYPE set REMOTE_PORT and REMOTE_EXTRA
 set_server_type
 
@@ -1629,11 +1678,19 @@ URL_new_cert=$(echo "$ca_all_loc" | grep "new-cert" | awk -F'"' '{print $4}')
 
 # if check_remote is true then connect and obtain the current certificate (if not forcing renewal)
 if [[ "${CHECK_REMOTE}" == "true" ]] && [[ $_FORCE_RENEW -eq 0 ]]; then
-  debug "getting certificate for $DOMAIN from remote server"
+  info "Contacting $DOMAIN on port ${REMOTE_PORT} to inspect current certificate"
   # shellcheck disable=SC2086
-  EX_CERT=$(echo \
-    | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null \
-    | openssl x509 2>/dev/null)
+  EX_CERT=$( {
+        if [[ "${BASH_VERSINFO[0]}${BASH_VERSINFO[1]}" -ge 43 ]]; then
+          echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null & PID=$!
+          sleep ${CHECK_CERT_TIMEOUT} & PIDW=$!
+          wait -n # Requires bash 4.3+
+          kill -9 "$PID" "$PIDW" 2>/dev/null
+        else
+          echo | openssl s_client -servername "${DOMAIN}" -connect "${DOMAIN}:${REMOTE_PORT}" ${REMOTE_EXTRA} 2>/dev/null
+        fi
+      } | openssl x509 2>/dev/null )
+
   if [[ ! -z "$EX_CERT" ]]; then # if obtained a cert
     if [[ -s "$CERT_FILE" ]]; then # if local exists
       CERT_LOCAL=$(openssl x509 -noout -fingerprint < "$CERT_FILE" 2>/dev/null)
@@ -1980,10 +2037,10 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
             check_result=$(nslookup -type=txt "_acme-challenge.${d}" "${ns}" \
                            | grep ^_acme -A2\
                            | grep '"'|awk -F'"' '{ print $2}')
-          elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
-            check_result=$($DNS_CHECK_FUNC TXT "_acme-challenge.${d}" "@${ns}" \
+          elif [[ "$DNS_CHECK_FUNC" =~ ^drill ]] || [[ "$DNS_CHECK_FUNC" =~ ^dig ]]; then
+            check_result=$($DNS_CHECK_FUNC "_acme-challenge.${d}" TXT "@${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
-          elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
+          elif [[ "$DNS_CHECK_FUNC" =~ ^host ]]; then
             check_result=$($DNS_CHECK_FUNC -t TXT "_acme-challenge.${d}" "${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           else

--- a/getssl
+++ b/getssl
@@ -429,7 +429,8 @@ check_getssl_upgrade() { # check if a more recent version of code is available a
   curl --silent "$CODE_LOCATION" --output "$TEMP_UPGRADE_FILE"
   errcode=$?
   if [[ $errcode -eq 60 ]]; then
-    error_exit "curl needs updating, your version does not support SNI (multiple SSL domains on a single IP)"
+    longmsg=$'Can not authenticate SSL peer. Your ca_bundle.crt and/or curl may need\nupdating. ca_bundle.crt can be updates with mk-ca-bundle.  Curl should\nsupport SNI (multiple SSL domains on a single IP)'
+    error_exit "$longmsg"
   elif [[ $errcode -gt 0 ]]; then
     error_exit "curl error : $errcode"
   fi

--- a/getssl
+++ b/getssl
@@ -1736,11 +1736,15 @@ if [[ "${CHECK_REMOTE}" == "true" ]] && [[ $_FORCE_RENEW -eq 0 ]]; then
           copy_file_to_location "full pem" \
                                 "$TEMP_DIR/${DOMAIN}_chain.pem" \
                                 "$DOMAIN_CHAIN_LOCATION"
+          umask 077
           cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
+          umask "$ORIG_UMASK"
           copy_file_to_location "private key and domain cert pem" \
                                 "$TEMP_DIR/${DOMAIN}_K_C.pem"  \
                                 "$DOMAIN_KEY_CERT_LOCATION"
+          umask 077
           cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
+          umask "$ORIG_UMASK"
           copy_file_to_location "full pem" \
                                 "$TEMP_DIR/${DOMAIN}.pem"  \
                                 "$DOMAIN_PEM_LOCATION"
@@ -2154,12 +2158,14 @@ if [[ ! -z "$DOMAIN_KEY_CERT_LOCATION" ]]; then
   else
     to_location="${DOMAIN_KEY_CERT_LOCATION}"
   fi
+  umask 077
   cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
   copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem"  "$to_location"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
   cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE::-4}.ec.crt" > "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"
   copy_file_to_location "private ec key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"  "${to_location}.ec"
   fi
+  umask "$ORIG_UMASK"
 fi
 # if DOMAIN_PEM_LOCATION is not blank, then create and copy file.
 if [[ ! -z "$DOMAIN_PEM_LOCATION" ]]; then
@@ -2168,12 +2174,14 @@ if [[ ! -z "$DOMAIN_PEM_LOCATION" ]]; then
   else
     to_location="${DOMAIN_PEM_LOCATION}"
   fi
+  umask 077
   cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
   copy_file_to_location "full key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem"  "$to_location"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
     cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE::-4}.ec.crt" "${CA_CERT::-4}.ec.crt" > "$TEMP_DIR/${DOMAIN}.pem.ec"
     copy_file_to_location "full ec key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem.ec"  "${to_location}.ec"
   fi
+  umask "$ORIG_UMASK"
 fi
 # end of copying certs.
 


### PR DESCRIPTION
Uses the GoDaddy "Developer" API to add and remove the ACME challenge
records.

This commit contains the validation hooks for GoDaddy DNS.  See the readme (00GoDaddy-README.txt)
for more information.  

There are 4 main files in this commit:
- dns_scripts/00GoDaddy-README.txt - user install instructions.
- dns_scripts/dns_add_godaddy - the DNS_ADD_COMMAND hook
- dns_scripts/dns_del_godaddy - the DNS_DEL_COMMAND hook
- dns_scripts/dns_godaddy - The worker module (-h provides additional usage)

The .git{ignore,attributes} prevent extraneous files from being committed, but aren't essential.

This was an afternoon project, and is at Beta quality - it works for me, but has received
limited testing.  Because it's a stand-alone plugin, I didn't study the getssl coding style.

It is configurable - you can have multiple sets of GoDaddy credentials as needed.
The credentials are (at this writing) free from GoDaddy, see the documentation for details.

It relies on [JSON.sh](/dominictarr/JSON.sh), which is available on github.

The documentation suggests a standard place for site-specific scripts - `~/.getssl/myscripts`.  

Enjoy.