### PR TITLE
Override $WORKING_DIR variable after XDG_BASE_DIRECTORIES

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use puppet, there is a [GetSSL Puppet module](https://github.com/dthielki
 
 ## Overview
 
-GetSSL was written in standard bash ( so it can be run on a server,  a desktop computer, or even a virtualbox) and add the checks, and certificates to a remote server ( providing you have a ssh with key, sftp or ftp access to the remote server).
+GetSSL was written in standard bash ( so it can be run on a server, a desktop computer, or even a virtualbox) and add the checks, and certificates to a remote server ( providing you have a ssh with key, sftp or ftp access to the remote server).
 
 ```
 getssl ver. 2.02

--- a/getssl
+++ b/getssl
@@ -1483,6 +1483,21 @@ if [[ -z "$DOMAIN" ]] && [[ ${_CHECK_ALL} -ne 1 ]]; then
   graceful_exit
 fi
 
+# if exist the ~/.config directory, use it as parent directory
+if [[ -d "${HOME}/.config" ]]; then
+  WORKING_DIR="${HOME}/.config/getssl"
+fi
+
+#if set $XDG_CONFIG_HOME environment variable, use it as parent directory
+if [[ ! -z ${XDG_CONFIG_HOME+x} ]]; then
+  WORKING_DIR="${XDG_CONFIG_HOME}/getssl"
+fi
+
+# if set $GETSSL_HOME enviroment variable, use it as parent directory
+if [[ ! -z ${GETSSL_HOME+x} ]]; then
+  WORKING_DIR="${GETSSL_HOME}"
+fi
+
 # if the "working directory" doesn't exist, then create it.
 if [[ ! -d "$WORKING_DIR" ]]; then
   debug "Making working directory - $WORKING_DIR"


### PR DESCRIPTION
First, use value of $GETSSL_HOME variable if exists
Second, use value of $XDG_CONFIG_HOME variable if exists
Third, use $HOME/.config directory if exists
Last, use default directory ~/.getssl as WORKING_DIR

Some Links
FreeDesktop - https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
ArchLinux - https://wiki.archlinux.org/index.php/XDG_Base_Directory_support