### PR TITLE
chmod remote file copied by ssh to be all-readable

### DIFF
--- a/getssl
+++ b/getssl
@@ -516,10 +516,12 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
         error_exit "problem copying file to the server using scp.
         scp $from ${to:4}"
       fi
+      servername=$(echo "$to" | awk -F":" '{print $2}')
+      tofile=$(echo "$to" | awk -F":" '{print $3}')
+      # shellcheck disable=SC2029
+      ssh "$servername" "chmod a+r $tofile"
       debug "userid $TOKEN_USER_ID"
       if [[ "$cert" == "challenge token" ]] && [[ ! -z "$TOKEN_USER_ID" ]]; then
-        servername=$(echo "$to" | awk -F":" '{print $2}')
-        tofile=$(echo "$to" | awk -F":" '{print $3}')
         debug "servername $servername"
         debug "file $tofile"
         # shellcheck disable=SC2029


### PR DESCRIPTION
This is for the case where remote umask is not world-readable:
something like 0027 or even 0077 (not even group-readable).

Remote file copied to /.well-known/ should perhaps be world-readable.
It really depends on web server configuration but we assume the most
common configuration.