### PR TITLE
DNS validation CNAME correction

### DIFF
--- a/getssl
+++ b/getssl
@@ -1981,13 +1981,13 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
                            | grep '"'|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
             check_result=$($DNS_CHECK_FUNC TXT "_acme-challenge.${d}" "@${ns}" \
-                           | grep ^_acme|awk -F'"' '{ print $2}')
+                           | awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
             check_result=$($DNS_CHECK_FUNC -t TXT "_acme-challenge.${d}" "${ns}" \
-                           | grep ^_acme|awk -F'"' '{ print $2}')
+                           | grep ' descriptive text '|awk -F'"' '{ print $2}')
           else
             check_result=$(nslookup -type=txt "_acme-challenge.${d}" "${ns}" \
-                           | grep ^_acme|awk -F'"' '{ print $2}')
+                           |awk -F'"' '{ print $2}')
           fi
           debug "expecting  $auth_key"
           debug "${ns} gave ... $check_result"


### PR DESCRIPTION
When you point the _acme-challenge record to a CNAME, the validation do not pass because of "grep ^_acme" that grep the very first response, but the valid one is the 2nd :
```
$ nslookup -type=txt _acme-challenge.example.com 8.8.4.4
Server:		8.8.4.4
Address:	8.8.4.4#53

Non-authoritative answer:
_acme-challenge.example.com	canonical name = test.example2.com.
test.example2.com	text = "LeTsEnCrYpT-tOkEn"
```