### PR TITLE
Use pattern to remove suffix instead of negative length substring

### DIFF
--- a/getssl
+++ b/getssl
@@ -184,10 +184,11 @@
 # 2017-01-30 issue #243 compatibility with bash 3.0 (2.08)
 # 2017-01-30 issue #243 additional compatibility with bash 3.0 (2.09)
 # 2017-02-18 add OCSP Must-Staple to the domain csr generation (2.10)
+# 2017-12-08 use pattern to remove suffix instead of negative length substring (2.11)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.10"
+VERSION="2.11"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
@@ -255,11 +256,11 @@ cert_archive() {  # Archive certificate file by copying files to dated archive d
   cp "$CA_CERT" "${DOMAIN_DIR}/archive/${date_time}/chain.crt"
   cat "$CERT_FILE" "$CA_CERT" > "${DOMAIN_DIR}/archive/${date_time}/fullchain.crt"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cp "${CERT_FILE::-4}.ec.crt" "${DOMAIN_DIR}/archive/${date_time}/${DOMAIN}.ec.crt"
+    cp "${CERT_FILE%.*}.ec.crt" "${DOMAIN_DIR}/archive/${date_time}/${DOMAIN}.ec.crt"
     cp "$DOMAIN_DIR/${DOMAIN}.ec.csr" "${DOMAIN_DIR}/archive/${date_time}/${DOMAIN}.ec.csr"
     cp "$DOMAIN_DIR/${DOMAIN}.ec.key" "${DOMAIN_DIR}/archive/${date_time}/${DOMAIN}.ec.key"
-    cp "${CA_CERT::-4}.ec.crt" "${DOMAIN_DIR}/archive/${date_time}/chain.ec.crt"
-    cat "${CERT_FILE::-4}.ec.crt" "${CA_CERT::-4}.ec.crt" > "${DOMAIN_DIR}/archive/${date_time}/fullchain.ec.crt"
+    cp "${CA_CERT%.*}.ec.crt" "${DOMAIN_DIR}/archive/${date_time}/chain.ec.crt"
+    cat "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "${DOMAIN_DIR}/archive/${date_time}/fullchain.ec.crt"
   fi
   umask "$ORIG_UMASK"
   debug "purging old GetSSL archives"
@@ -653,8 +654,8 @@ create_key() { # create a domain key (if it doesn't already exist)
     esac
     umask "$ORIG_UMASK"
     # remove csr on generation of new domain key
-    if [[ -e "${key_loc::-4}.csr" ]]; then
-      rm -f "${key_loc::-4}.csr"
+    if [[ -e "${key_loc%.*}.csr" ]]; then
+      rm -f "${key_loc%.*}.csr"
     fi
   fi
 }
@@ -2043,8 +2044,8 @@ get_certificate "$DOMAIN_DIR/${DOMAIN}.csr" \
                 "$CA_CERT"
 if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
   get_certificate "$DOMAIN_DIR/${DOMAIN}.ec.csr" \
-                  "${CERT_FILE::-4}.ec.crt" \
-                  "${CA_CERT::-4}.ec.crt"
+                  "${CERT_FILE%.*}.ec.crt" \
+                  "${CA_CERT%.*}.ec.crt"
 fi
 
 # create Archive of new certs and keys.
@@ -2060,18 +2061,18 @@ copy_file_to_location "CA certificate" "$CA_CERT" "$CA_CERT_LOCATION"
 if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
   if [[ ! -z "$DOMAIN_CERT_LOCATION" ]]; then
     copy_file_to_location "ec domain certificate" \
-                          "${CERT_FILE::-4}.ec.crt" \
-                          "${DOMAIN_CERT_LOCATION::-4}.ec.crt"
+                          "${CERT_FILE%.*}.ec.crt" \
+                          "${DOMAIN_CERT_LOCATION%.*}.ec.crt"
   fi
   if [[ ! -z "$DOMAIN_KEY_LOCATION" ]]; then
   copy_file_to_location "ec private key" \
                         "$DOMAIN_DIR/${DOMAIN}.ec.key" \
-                        "${DOMAIN_KEY_LOCATION::-4}.ec.key"
+                        "${DOMAIN_KEY_LOCATION%.*}.ec.key"
   fi
   if [[ ! -z "$CA_CERT_LOCATION" ]]; then
   copy_file_to_location "ec CA certificate" \
-                        "${CA_CERT::-4}.ec.crt" \
-                        "${CA_CERT_LOCATION::-4}.ec.crt"
+                        "${CA_CERT%.*}.ec.crt" \
+                        "${CA_CERT_LOCATION%.*}.ec.crt"
   fi
 fi
 
@@ -2085,7 +2086,7 @@ if [[ ! -z "$DOMAIN_CHAIN_LOCATION" ]]; then
   cat "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}_chain.pem"
   copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem"  "$to_location"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cat "${CERT_FILE::-4}.ec.crt" "${CA_CERT::-4}.ec.crt" > "$TEMP_DIR/${DOMAIN}_chain.pem.ec"
+    cat "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_chain.pem.ec"
     copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem.ec"  "${to_location}.ec"
   fi
 fi
@@ -2099,7 +2100,7 @@ if [[ ! -z "$DOMAIN_KEY_CERT_LOCATION" ]]; then
   cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
   copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem"  "$to_location"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-  cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE::-4}.ec.crt" > "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"
+  cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"
   copy_file_to_location "private ec key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"  "${to_location}.ec"
   fi
 fi
@@ -2113,7 +2114,7 @@ if [[ ! -z "$DOMAIN_PEM_LOCATION" ]]; then
   cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
   copy_file_to_location "full key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem"  "$to_location"
   if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE::-4}.ec.crt" "${CA_CERT::-4}.ec.crt" > "$TEMP_DIR/${DOMAIN}.pem.ec"
+    cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}.pem.ec"
     copy_file_to_location "full ec key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem.ec"  "${to_location}.ec"
   fi
 fi


### PR DESCRIPTION
Remove filename extensions using suffix pattern matching instead of negative length substrings, which fail for bash prior to 4.2-alpha and some later macOS versions.