### PR TITLE
Make sure wildcards are escaped properly

### DIFF
--- a/getssl
+++ b/getssl
@@ -2116,7 +2116,7 @@ if [[ $API -eq 2 ]]; then
   dn=0
   for d in $alldomains; do
     # get authorizations link
-    AuthLink[$dn]=$(json_get "$response" "identifiers" "value" "$d" "authorizations" "x")
+    AuthLink[$dn]=$(json_get "$response" "identifiers" "value" "${d/\*/\\*}" "authorizations" "x")
     debug "authorizations link for $d - ${AuthLink[$dn]}"
     ((dn++))
   done


### PR DESCRIPTION
Make sure wildcards are escaped properly whenever the list of SANs contains any of them. This should fix the 'uri json was blank' issue occurring whenever the SANs list contain any wildcard in the specified subdomain.