### PR TITLE
issue #381 add DNS_FOLLOW_CNAMES functionality (2.11)

### DIFF
--- a/getssl
+++ b/getssl
@@ -1981,7 +1981,7 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
         while [[ "$check_dns" == "fail" ]]; do
           if [[ "$os" == "cygwin" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              while [[ $cname_check -gt 0 ]]; then
+              while [[ $cname_check -gt 0 ]]; do
                 cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
                              | grep ^_acme -A2\
                              | grep '"'|awk '{ print $5}')
@@ -1999,7 +1999,7 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
                            | grep '"'|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              while [[ $cname_check -gt 0 ]]; then
+              while [[ $cname_check -gt 0 ]]; do
                 cname_fqdn=$($DNS_CHECK_FUNC CNAME "${check_fqdn}" "@${ns}" \
                              | grep ^_acme|awk '{ print $5}')
 
@@ -2015,7 +2015,7 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
                            | grep ^_acme|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              while [[ $cname_check -gt 0 ]]; then
+              while [[ $cname_check -gt 0 ]]; do
                 cname_fqdn=$($DNS_CHECK_FUNC -t CNAME "${check_fqdn}" "${ns}" \
                              | grep ^_acme|awk '{ print $5}')
 
@@ -2031,7 +2031,7 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
                            | grep ^_acme|awk -F'"' '{ print $2}')
           else
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              while [[ $cname_check -gt 0 ]]; then
+              while [[ $cname_check -gt 0 ]]; do
                 cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
                              | grep ^_acme|awk '{ print $5}')
 

--- a/getssl
+++ b/getssl
@@ -204,7 +204,7 @@ CSR_SUBJECT="/"
 DEACTIVATE_AUTH="false"
 DEFAULT_REVOKE_CA="https://acme-v01.api.letsencrypt.org"
 DNS_EXTRA_WAIT=""
-DNS_FOLLOW_CNAMES="false"
+DNS_FOLLOW_CNAMES="true"
 DNS_WAIT=10
 DOMAIN_KEY_LENGTH=4096
 DUAL_RSA_ECDSA="false"
@@ -1977,16 +1977,21 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
         ntries=0
         check_dns="fail"
         check_fqdn="_acme-challenge.${d}"
+        cname_check=1
         while [[ "$check_dns" == "fail" ]]; do
           if [[ "$os" == "cygwin" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
-                           | grep ^_acme -A2\
-                           | grep '"'|awk '{ print $5}')
+              while [[ $cname_check -gt 0 ]]; then
+                cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
+                             | grep ^_acme -A2\
+                             | grep '"'|awk '{ print $5}')
 
-              if [[ "$cname_fqdn" != "" ]]; then
-                check_fqdn=$cname_fqdn
-              fi
+                if [[ "$cname_fqdn" != "" ]]; then
+                  check_fqdn=$cname_fqdn
+                else
+                  cname_check=0
+                fi
+              done
             fi
   
             check_result=$(nslookup -type=txt "${check_fqdn}" "${ns}" \
@@ -1994,36 +1999,48 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
                            | grep '"'|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              cname_fqdn=$($DNS_CHECK_FUNC CNAME "${check_fqdn}" "@${ns}" \
-                           | grep ^_acme|awk '{ print $5}')
+              while [[ $cname_check -gt 0 ]]; then
+                cname_fqdn=$($DNS_CHECK_FUNC CNAME "${check_fqdn}" "@${ns}" \
+                             | grep ^_acme|awk '{ print $5}')
 
-              if [[ "$cname_fqdn" != "" ]]; then
-                check_fqdn=$cname_fqdn
-              fi
+                if [[ "$cname_fqdn" != "" ]]; then
+                  check_fqdn=$cname_fqdn
+                else
+                  cname_check=0
+                fi
+              done
             fi
 
             check_result=$($DNS_CHECK_FUNC TXT "${check_fqdn}" "@${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              cname_fqdn=$($DNS_CHECK_FUNC -t CNAME "${check_fqdn}" "${ns}" \
-                           | grep ^_acme|awk '{ print $5}')
+              while [[ $cname_check -gt 0 ]]; then
+                cname_fqdn=$($DNS_CHECK_FUNC -t CNAME "${check_fqdn}" "${ns}" \
+                             | grep ^_acme|awk '{ print $5}')
 
-              if [[ "$cname_fqdn" != "" ]]; then
-                check_fqdn=$cname_fqdn
-              fi
+                if [[ "$cname_fqdn" != "" ]]; then
+                  check_fqdn=$cname_fqdn
+                else
+                  cname_check=0
+                fi
+              done
             fi
 
             check_result=$($DNS_CHECK_FUNC -t TXT "${check_fqdn}" "${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           else
             if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
-              cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
-                           | grep ^_acme|awk '{ print $5}')
+              while [[ $cname_check -gt 0 ]]; then
+                cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
+                             | grep ^_acme|awk '{ print $5}')
 
-              if [[ "$cname_fqdn" != "" ]]; then
-                check_fqdn=$cname_fqdn
-              fi
+                if [[ "$cname_fqdn" != "" ]]; then
+                  check_fqdn=$cname_fqdn
+                else
+                  cname_check=0
+                fi
+              done
             fi
 
             check_result=$(nslookup -type=txt "${check_fqdn}" "${ns}" \

--- a/getssl
+++ b/getssl
@@ -184,10 +184,11 @@
 # 2017-01-30 issue #243 compatibility with bash 3.0 (2.08)
 # 2017-01-30 issue #243 additional compatibility with bash 3.0 (2.09)
 # 2017-02-18 add OCSP Must-Staple to the domain csr generation (2.10)
+# 2018-05-03 issue #381 add DNS_FOLLOW_CNAMES functionality (2.11)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.10"
+VERSION="2.11"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
@@ -203,6 +204,7 @@ CSR_SUBJECT="/"
 DEACTIVATE_AUTH="false"
 DEFAULT_REVOKE_CA="https://acme-v01.api.letsencrypt.org"
 DNS_EXTRA_WAIT=""
+DNS_FOLLOW_CNAMES="false"
 DNS_WAIT=10
 DOMAIN_KEY_LENGTH=4096
 DUAL_RSA_ECDSA="false"
@@ -1974,19 +1976,57 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
         debug "checking dns at $ns"
         ntries=0
         check_dns="fail"
+        check_fqdn="_acme-challenge.${d}"
         while [[ "$check_dns" == "fail" ]]; do
           if [[ "$os" == "cygwin" ]]; then
-            check_result=$(nslookup -type=txt "_acme-challenge.${d}" "${ns}" \
+            if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
+              cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
+                           | grep ^_acme -A2\
+                           | grep '"'|awk '{ print $5}')
+
+              if [[ "$cname_fqdn" != "" ]]; then
+                check_fqdn=$cname_fqdn
+              fi
+            fi
+  
+            check_result=$(nslookup -type=txt "${check_fqdn}" "${ns}" \
                            | grep ^_acme -A2\
                            | grep '"'|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
-            check_result=$($DNS_CHECK_FUNC TXT "_acme-challenge.${d}" "@${ns}" \
+            if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
+              cname_fqdn=$($DNS_CHECK_FUNC CNAME "${check_fqdn}" "@${ns}" \
+                           | grep ^_acme|awk '{ print $5}')
+
+              if [[ "$cname_fqdn" != "" ]]; then
+                check_fqdn=$cname_fqdn
+              fi
+            fi
+
+            check_result=$($DNS_CHECK_FUNC TXT "${check_fqdn}" "@${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
-            check_result=$($DNS_CHECK_FUNC -t TXT "_acme-challenge.${d}" "${ns}" \
+            if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
+              cname_fqdn=$($DNS_CHECK_FUNC -t CNAME "${check_fqdn}" "${ns}" \
+                           | grep ^_acme|awk '{ print $5}')
+
+              if [[ "$cname_fqdn" != "" ]]; then
+                check_fqdn=$cname_fqdn
+              fi
+            fi
+
+            check_result=$($DNS_CHECK_FUNC -t TXT "${check_fqdn}" "${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           else
-            check_result=$(nslookup -type=txt "_acme-challenge.${d}" "${ns}" \
+            if [[ $DNS_FOLLOW_CNAMES == "true" ]]; then
+              cname_fqdn=$(nslookup -type=cname "${check_fqdn}" "${ns}" \
+                           | grep ^_acme|awk '{ print $5}')
+
+              if [[ "$cname_fqdn" != "" ]]; then
+                check_fqdn=$cname_fqdn
+              fi
+            fi
+
+            check_result=$(nslookup -type=txt "${check_fqdn}" "${ns}" \
                            | grep ^_acme|awk -F'"' '{ print $2}')
           fi
           debug "expecting  $auth_key"


### PR DESCRIPTION
This will do infinite recursive checking for CNAMES.  Perhaps we might want to limit how deep it goes.  Adds the config option DNS_FOLLOW_CNAMES="true" as the default.

I don't have access to all of the system types for testing this... but, it's really just using the existing functionality.