### PR TITLE
Use HTTP 1.1 as workaround atm

### DIFF
--- a/getssl
+++ b/getssl
@@ -1136,7 +1136,14 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
 
   CURL_HEADER="$TEMP_DIR/curl.header"
   dp="$TEMP_DIR/curl.dump"
-  CURL="curl --http1.1 --silent --dump-header $CURL_HEADER "
+
+  CURL="curl "
+  if [[ "$($CURL -V | head -1 | cut -d' ' -f2 )" > "7.33" ]]; then
+    CURL="$CURL --http1.1 "
+  fi
+
+  CURL="$CURL --silent --dump-header $CURL_HEADER "
+
   if [[ ${_USE_DEBUG} -eq 1 ]]; then
     CURL="$CURL --trace-ascii $dp "
   fi

--- a/getssl
+++ b/getssl
@@ -184,10 +184,11 @@
 # 2017-01-30 issue #243 compatibility with bash 3.0 (2.08)
 # 2017-01-30 issue #243 additional compatibility with bash 3.0 (2.09)
 # 2017-02-18 add OCSP Must-Staple to the domain csr generation (2.10)
+# 2017-09-30 issue #423 Use HTTP 1.1 as workaround atm (2.11)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.10"
+VERSION="2.11"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
@@ -1135,7 +1136,7 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
 
   CURL_HEADER="$TEMP_DIR/curl.header"
   dp="$TEMP_DIR/curl.dump"
-  CURL="curl --silent --dump-header $CURL_HEADER "
+  CURL="curl --http1.1 --silent --dump-header $CURL_HEADER "
   if [[ ${_USE_DEBUG} -eq 1 ]]; then
     CURL="$CURL --trace-ascii $dp "
   fi


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fix #423, fix #427
| Related issues/PRs | -
| License | GPL3.0+

#### What's in this PR?

Sets curl to use `--http1.1` for newly HTTP2 activated ACME API

#### Why?

With HTTP2 response headers are all lowercase. This is a quickfix to get getssl working again, a follow up to support HTTP2 will be created.

#### To Do

- [ ] Create follow-up issue