### PR TITLE
Case insensitive processing of agreement url because of HTTP/2

### DIFF
--- a/getssl
+++ b/getssl
@@ -185,10 +185,11 @@
 # 2017-01-30 issue #243 additional compatibility with bash 3.0 (2.09)
 # 2017-02-18 add OCSP Must-Staple to the domain csr generation (2.10)
 # 2019-09-30 issue #423 Use HTTP 1.1 as workaround atm (2.11)
+# 2019-10-02 issue #425 Case insensitive processing of agreement url because of HTTP/2 (2.12)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.11"
+VERSION="2.12"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
@@ -1483,7 +1484,7 @@ if [[ $_REVOKE -eq 1 ]]; then
 fi
 
 # get latest agreement from CA (as default)
-AGREEMENT=$(curl -I "${CA}/terms" 2>/dev/null | awk '$1 ~ "Location:" {print $2}'|tr -d '\r')
+AGREEMENT=$(curl -I "${CA}/terms" 2>/dev/null | awk 'tolower($1) ~ "location:" {print $2}'|tr -d '\r')
 
 # if nothing in command line, print help and exit.
 if [[ -z "$DOMAIN" ]] && [[ ${_CHECK_ALL} -ne 1 ]]; then


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #425 
| Related issues/PRs | -
| License | GPL3.0+

#### What's in this PR?

Fixes the awk processing to get the redirect location to be case insensitive because of lowercased HTTP/2 headers.