### PR TITLE
Update order of DNS_CHECK_FUNC

### DIFF
--- a/getssl
+++ b/getssl
@@ -1455,7 +1455,7 @@ get_os
 requires which
 requires openssl
 requires curl
-requires nslookup drill dig host DNS_CHECK_FUNC
+requires nslookup host drill dig DNS_CHECK_FUNC
 requires awk
 requires tr
 requires date


### PR DESCRIPTION
Preferring `host` over `drill` and `dig` for assignment to DNS_CHECK_FUNC.

This is a workaround for issue #364 where machines without `nslookup` try either drill/dig but fail because the condition that sets `$check_dns` for those applications always fails because it does not match their output format.  Ideally, one could fix those conditions so that drill and dig would also both work, but I do not know how to resolve the debate that has been raised about the appropriateness of querying the SOA record.