### PR TITLE
Only select first URL returned from acme-v02

### DIFF
--- a/getssl
+++ b/getssl
@@ -2248,7 +2248,7 @@ for d in $alldomains; do
         token=$(json_get "$response" "challenges" "type" "http-01" "token")
         debug token "$token"
         # get the uri from the http component
-        uri=$(json_get "$response" "challenges" "type" "http-01" "url")
+        uri=$(json_get "$response" "challenges" "type" "http-01" "url" | head -n1)
         debug uri "$uri"
       fi
 


### PR DESCRIPTION
acme-v02 API can return more than 1 URL inside a http-01 challenge object, this change just selects the first one which appears to always be the one we want.

Example of the problem here: https://gist.githubusercontent.com/2ZZ/74bd2cb3ad2bd4f7a578fa9077ac383d/raw/d342aac4c175f1ca1b04b0070839fffd739232ff/getssl-test.sh