### PR TITLE
Fix #462 use POST-as-GET requests on ACMEv2 endpoints

### DIFF
--- a/getssl
+++ b/getssl
@@ -2185,7 +2185,7 @@ for d in $alldomains; do
         uri=$(json_get "$response" "uri" "dns-01")
         debug uri "$uri"
       else # APIv2
-        response=$(curl --user-agent "$CURL_USERAGENT" --silent "${AuthLink[$dn]}" 2>/dev/null)
+        send_signed_request "${AuthLink[$dn]}" ""
         debug "authlink response = $response"
         # get the token from the http-01 component
         token=$(json_get "$response" "challenges" "type" "dns-01" "token")
@@ -2242,7 +2242,7 @@ for d in $alldomains; do
         uri=$(json_get "$response" "uri" "http-01")
         debug uri "$uri"
       else # APIv2
-        response=$(curl --user-agent "$CURL_USERAGENT" --silent "${AuthLink[$dn]}" 2>/dev/null)
+        send_signed_request "${AuthLink[$dn]}" ""
         debug "authlink response = $response"
         # get the token from the http-01 component
         token=$(json_get "$response" "challenges" "type" "http-01" "token")
@@ -2488,8 +2488,8 @@ reload_service
 if [[ "$DEACTIVATE_AUTH" == "true" ]]; then
   debug "in deactivate list is $deactivate_url_list"
   for deactivate_url in $deactivate_url_list; do
-    resp=$(curl --user-agent "$CURL_USERAGENT" "$deactivate_url" 2>/dev/null)
-    d=$(json_get "$resp" "hostname")
+    send_signed_request "$deactivate_url" ""
+    d=$(json_get "$response" "hostname")
     info "deactivating domain $d"
     debug "deactivating  $deactivate_url"
     send_signed_request "$deactivate_url" "{\"resource\": \"authz\", \"status\": \"deactivated\"}"


### PR DESCRIPTION
Ref https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380