### PR TITLE
fix #368

### DIFF
--- a/getssl
+++ b/getssl
@@ -2186,7 +2186,7 @@ if [[ $API -eq 2 ]]; then
   for d in $alldomains; do
     dstring="${dstring}{\"type\":\"dns\",\"value\":\"$d\"},"
   done
-  dstring="${dstring::${#dstring}-1}]"
+  dstring="${dstring%?}]"
   # request NewOrder currently seems to ignore the dates ....
   #  dstring="${dstring},\"notBefore\": \"$(date -d "-1 hour" --utc +%FT%TZ)\""
   #  dstring="${dstring},\"notAfter\": \"$(date -d "2 days" --utc +%FT%TZ)\""


### PR DESCRIPTION
As suggested in #368 by @rodyager, this will fix syntax errors for old bash versions, but also be compatible with bash >=v3 (tested in docker with v3 - v5).
Documented here: https://wiki.bash-hackers.org/syntax/pe#substring_removal