### PR TITLE
Bugfixs for json_awk and nslookup

### DIFF
--- a/getssl
+++ b/getssl
@@ -813,7 +813,7 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
     return
   fi
 
-  res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d" ${gad_s})
+  res=$(nslookup -debug -type=soa -type=ns "$gad_d" ${gad_s})
 
   if [[ "$(echo "$res" | grep -c "Non-authoritative")" -gt 0 ]]; then
     # this is a Non-authoritative server, need to check for an authoritative one.
@@ -826,9 +826,9 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
   fi
 
   if [[ -z "$gad_s" ]]; then
-    res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d")
+    res=$(nslookup -debug -type=soa -type=ns "$gad_d")
   else
-    res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d" "${gad_s}")
+    res=$(nslookup -debug -type=soa -type=ns "$gad_d" "${gad_s}")
   fi
 
   if [[ "$(echo "$res" | grep -c "canonical name")" -gt 0 ]]; then

--- a/getssl
+++ b/getssl
@@ -1027,7 +1027,7 @@ info() { # write out info as long as the quiet flag has not been set.
 
 json_awk() { # AWK json converter used for API2 - needs tidying up ;)
 # shellcheck disable=SC2086
-echo $1 | awk '
+echo "$1" | tr -d '\n' | awk '
 {
   tokenize($0) # while(get_token()) {print TOKEN}
   if (0 == parse()) {
@@ -1173,8 +1173,8 @@ function scream(msg) {
 }
 
 function tokenize(a1,pq,pb,ESCAPE,CHAR,STRING,NUMBER,KEYWORD,SPACE) {
-  SPACE="[[:space:]]+"
-  gsub(/"[^[:cntrl:]"\\]*((\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})[^[:cntrl:]"\\]*)*"|-?(0|[1-9][0-9]*)([.][0-9]*)?([eE][+-]?[0-9]*)?|null|false|true|[[:space:]]+|./, "\n&", a1)
+  SPACE="[ \t\n]+"
+  gsub(/"[^\001-\037"\\]*((\\[^u\001-\037]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])[^\001-\037"\\]*)*"|-?(0|[1-9][0-9]*)([.][0-9]*)?([eE][+-]?[0-9]*)?|null|false|true|[ \t\n]+|./, "\n&", a1)
   gsub("\n" SPACE, "\n", a1)
   sub(/^\n/, "", a1)
   ITOKENS=0 # get_token() helper


### PR DESCRIPTION
First a small fix related to #332 where the most recent versions of the bind nslookup is not accepting `-debug=1`

Second (related to #421) is a fix to allow json_awk to run on the majority of awk versions.
Tested on gawk-v4, gawk-v5, mawk-1.3.3, mawk-1.3.4, busybox-awk-1.30.1, original-awk-2012-12-20-6 as well as gawk not in a UTF-8 locale.

Example test file (20130418-issue-001-test.json from JSON.awk):
``` json
{"sh": "[ -r 'k.cfg' ] || echo \"# k.cfg - `date`\" >'k.cfg';s=$(awk \"`echo -n 'BEGIN{nf=1} /^@Bs*mode=/{sub(/=.*/,@Q=123@Q);nf=0} {print} END{if(nf) print @Qmode=123@Q}'|sed 's/@Q/\\x22/g;s/@B/\\x5C/g'`\" 'k.cfg') && [ 0 != ${#s} ] && echo -n \"$s\" >'k.cfg'"}
```

And many others in: https://github.com/nst/JSONTestSuite
For that list this change does pass a couple of extra (trivial) cases.
