### PR TITLE
Fix Debian nslookup error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,33 @@ services:
           - i.alpine.getssl.test
           - j.alpine.getssl.test
           - k.alpine.getssl.test
+  getssl-debian:
+    build:
+      context: .
+      dockerfile: test/Dockerfile-debian
+    container_name: getssl-debian
+    volumes:
+      - .:/getssl
+    environment:
+      GETSSL_HOST: debian.getssl.test
+      GETSSL_IP: 10.30.50.7
+      NGINX_CONFIG: /etc/nginx/sites-enabled/default
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.7
+        aliases:
+          -   debian.getssl.test
+          - a.debian.getssl.test
+          - b.debian.getssl.test
+          - c.debian.getssl.test
+          - d.debian.getssl.test
+          - e.debian.getssl.test
+          - f.debian.getssl.test
+          - g.debian.getssl.test
+          - h.debian.getssl.test
+          - i.debian.getssl.test
+          - j.debian.getssl.test
+          - k.debian.getssl.test
   getssl-ubuntu18-no-gawk:
     build:
       context: .
@@ -111,12 +138,12 @@ services:
       - .:/getssl
     environment:
       GETSSL_HOST: ubuntu18-no-gawk.getssl.test
-      GETSSL_IP: 10.30.50.7
+      GETSSL_IP: 10.30.50.8
       NGINX_CONFIG: /etc/nginx/sites-enabled/default
       TEST_AWK: "yes"
     networks:
       acmenet:
-        ipv4_address: 10.30.50.7
+        ipv4_address: 10.30.50.8
         aliases:
           - ubuntu18-no-gawk.getssl.test
 

--- a/getssl
+++ b/getssl
@@ -813,7 +813,7 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
     return
   fi
 
-  res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d" ${gad_s})
+  res=$(nslookup -debug -type=soa -type=ns "$gad_d" ${gad_s})
 
   if [[ "$(echo "$res" | grep -c "Non-authoritative")" -gt 0 ]]; then
     # this is a Non-authoritative server, need to check for an authoritative one.
@@ -826,9 +826,9 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
   fi
 
   if [[ -z "$gad_s" ]]; then
-    res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d")
+    res=$(nslookup -debug -type=soa -type=ns "$gad_d")
   else
-    res=$(nslookup -debug=1 -type=soa -type=ns "$gad_d" "${gad_s}")
+    res=$(nslookup -debug -type=soa -type=ns "$gad_d" "${gad_s}")
   fi
 
   if [[ "$(echo "$res" | grep -c "canonical name")" -gt 0 ]]; then
@@ -838,13 +838,17 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
     gad_d=$(echo "$res"| awk '$1 ~ "->" {print $2; exit}')
   fi
 
-  all_auth_dns_servers=$(nslookup -type=soa -type=ns "$gad_d" "$gad_s" \
-                        | awk ' $2 ~ "nameserver" {print $4}' \
-                        | sed 's/\.$//g'| tr '\n' ' ')
-  if [[ $CHECK_ALL_AUTH_DNS == "true" ]]; then
-    primary_ns="$all_auth_dns_servers"
+  if [[ "$gad_d" == "" ]]; then
+    info "Cannot find an authorative DNS server for $1"
   else
-    primary_ns=$(echo "$all_auth_dns_servers" | awk '{print $1}')
+    all_auth_dns_servers=$(nslookup -type=soa -type=ns "$gad_d" "$gad_s" \
+                            | awk ' $2 ~ "nameserver" {print $4}' \
+                            | sed 's/\.$//g'| tr '\n' ' ')
+    if [[ $CHECK_ALL_AUTH_DNS == "true" ]]; then
+        primary_ns="$all_auth_dns_servers"
+    else
+        primary_ns=$(echo "$all_auth_dns_servers" | awk '{print $1}')
+    fi
   fi
 }
 

--- a/test/Dockerfile-debian
+++ b/test/Dockerfile-debian
@@ -1,0 +1,21 @@
+FROM debian:latest
+
+# Update and install required software
+RUN apt-get update --fix-missing
+RUN apt-get install -y git curl dnsutils wget gawk nginx-light # linux-libc-dev make gcc binutils
+
+WORKDIR /root
+RUN mkdir /etc/nginx/pki
+RUN mkdir /etc/nginx/pki/private
+
+# Prevent "Can't load /root/.rnd into RNG" error from openssl
+# RUN touch /root/.rnd
+
+# BATS (Bash Automated Testings)
+RUN git clone https://github.com/bats-core/bats-core.git /bats-core
+RUN git clone https://github.com/jasonkarns/bats-support /bats-support
+RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN /bats-core/install.sh /usr/local
+
+# Run eternal loop - for testing
+CMD tail -f /dev/null

--- a/test/run-all-tests.sh
+++ b/test/run-all-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+docker exec -it getssl-alpine bats /getssl/test
 docker exec -it getssl-centos6 bats /getssl/test
+docker exec -it getssl-debian bats /getssl/test
 docker exec -it getssl-ubuntu18 bats /getssl/test
 docker exec -it getssl-ubuntu18-no-gawk bats /getssl/test/5-old-awk-error.bats

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -18,7 +18,7 @@ setup_environment() {
     fi
 
     curl -X POST -d '{"host":"'"$GETSSL_HOST"'", "addresses":["'"$GETSSL_IP"'"]}' http://10.30.50.3:8055/add-a
-    cp ${CODE_DIR}/test/test-config/nginx-ubuntu-no-ssl ${NGINX_CONFIG}
+    cp ${CODE_DIR}/test/test-config/nginx-ubuntu-no-ssl "${NGINX_CONFIG}"
     /getssl/test/restart-nginx
 }
 


### PR DESCRIPTION
nslookup -debug=1 generates an error on newer versions of dnsutils.  Changing to -debug works on all the currently tested distributions.