### PR TITLE
Fix domain template url

### DIFF
--- a/getssl
+++ b/getssl
@@ -214,10 +214,11 @@
 # 2020-02-13 Fix bug with copying to all locations when creating RSA and ECDSA certs (2.20)
 # 2020-02-22 Change sign_string to use openssl asn1parse (better fix for #424)
 # 2020-02-23 Add dig to config check for systems without drill (ubuntu)
+# 2020-03-23 Fix staging server URL in domain template
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.20"
+VERSION="2.21"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096

--- a/getssl
+++ b/getssl
@@ -1890,7 +1890,7 @@ write_domain_template() { # write out a template file for a domain.
 	# see https://github.com/srvrco/getssl/wiki/Example-config-files for example configs
 	#
 	# The staging server is best for testing
-	#CA="https://acme-staging-v02.api.letsencrypt.org/"
+	#CA="https://acme-staging-v02.api.letsencrypt.org"
 	# This server issues full certificates, however has rate limits
 	#CA="https://acme-v02.api.letsencrypt.org"
 


### PR DESCRIPTION
This is very minor, but the trailing slash of the Let's Encrypt staging server URL broke API discovery (client was trying https://acme-staging-v02.api.letsencrypt.org//directory, which results in a 403). The "Unknown API" error confused me quite a bit...