### PR TITLE
Improvements: alternative working dirs and -i|--install command

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run test suite on Ubuntu18
         run: test/run-test.sh ubuntu18
   test-ubuntu-staging:
+    needs: test-centos7-staging
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Lint check
-        uses: azohra/shell-linter@v0.2.0
+        uses: azohra/shell-linter@v0.3.0
         with:
           path: "getssl"

--- a/getssl
+++ b/getssl
@@ -220,11 +220,12 @@
 # 2020-03-23 Fix staging server URL in domain template (2.21)
 # 2020-03-30 Fix error message find_dns_utils from over version of "command"
 # 2020-03-30 Fix problems if domain name isn't in lowercase (2.22)
-# 2020-04-16 Add alternative working dirs '/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl'
+# 2020-04-16 Add alternative working dirs '/etc/getssl/' '${PROGDIR}/conf' '${PROGDIR}/.getssl'
 # 2020-04-16 Add -i|--install command line option (2.23)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
+PROGDIR="$(cd "$(dirname "$0")" || exit; pwd -P;)"
 VERSION="2.23"
 
 # defaults
@@ -263,7 +264,7 @@ TEMP_UPGRADE_FILE=""
 TOKEN_USER_ID=""
 USE_SINGLE_ACL="false"
 VALIDATE_VIA_DNS=""
-WORKING_DIR_CANDIDATES=('/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl' '~/.getssl')
+WORKING_DIR_CANDIDATES=("/etc/getssl/" "${PROGDIR}/conf" "${PROGDIR}/.getssl" "${HOME}/.getssl")
 _CHECK_ALL=0
 _CREATE_CONFIG=0
 _FORCE_RENEW=0
@@ -2298,7 +2299,6 @@ fi
 # Test working directory candidates if unset. Last candidate defaults (~/getssl/)
 if [[ -z "${WORKING_DIR}" ]]
 then
-  SCRIPTDIR="$(cd "$(dirname "$0")"; pwd -P;)"
   for WDCC in $(seq 0 $((${#WORKING_DIR_CANDIDATES[@]}-1)) )
   do
     WORKING_DIR="$(eval echo "${WORKING_DIR_CANDIDATES[$WDCC]}")"

--- a/getssl
+++ b/getssl
@@ -221,11 +221,11 @@
 # 2020-03-30 Fix error message find_dns_utils from over version of "command"
 # 2020-03-30 Fix problems if domain name isn't in lowercase (2.22)
 # 2020-04-16 Add alternative working dirs '/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl'
-# 2020-04-16 Add -i|--install command line option
+# 2020-04-16 Add -i|--install command line option (2.23)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
-VERSION="2.22"
+VERSION="2.23"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096

--- a/getssl
+++ b/getssl
@@ -221,6 +221,7 @@
 # 2020-03-30 Fix error message find_dns_utils from over version of "command"
 # 2020-03-30 Fix problems if domain name isn't in lowercase (2.22)
 # 2020-04-16 Add alternative working dirs '/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl'
+# 2020-04-16 Add -i|--install command line option
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
@@ -303,6 +304,79 @@ cert_archive() {  # Archive certificate file by copying files to dated archive d
   umask "$ORIG_UMASK"
   debug "purging old GetSSL archives"
   purge_archive "$DOMAIN_DIR"
+}
+
+cert_install() {  # copy certs to the correct location (creating concatenated files as required)
+  umask 077
+
+  copy_file_to_location "domain certificate" "$CERT_FILE" "$DOMAIN_CERT_LOCATION"
+  copy_file_to_location "private key" "$DOMAIN_DIR/${DOMAIN}.key" "$DOMAIN_KEY_LOCATION"
+  copy_file_to_location "CA certificate" "$CA_CERT" "$CA_CERT_LOCATION"
+  if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
+    if [[ -n "$DOMAIN_CERT_LOCATION" ]]; then
+      copy_file_to_location "ec domain certificate" \
+                            "${CERT_FILE%.*}.ec.crt" \
+                            "${DOMAIN_CERT_LOCATION}" \
+                            "ec"
+    fi
+    if [[ -n "$DOMAIN_KEY_LOCATION" ]]; then
+      copy_file_to_location "ec private key" \
+                            "$DOMAIN_DIR/${DOMAIN}.ec.key" \
+                            "${DOMAIN_KEY_LOCATION}" \
+                            "ec"
+    fi
+    if [[ -n "$CA_CERT_LOCATION" ]]; then
+      copy_file_to_location "ec CA certificate" \
+                            "${CA_CERT%.*}.ec.crt" \
+                            "${CA_CERT_LOCATION%.*}.crt" \
+                            "ec"
+    fi
+  fi
+
+  # if DOMAIN_CHAIN_LOCATION is not blank, then create and copy file.
+  if [[ -n "$DOMAIN_CHAIN_LOCATION" ]]; then
+    if [[ "$(dirname "$DOMAIN_CHAIN_LOCATION")" == "." ]]; then
+      to_location="${DOMAIN_DIR}/${DOMAIN_CHAIN_LOCATION}"
+    else
+      to_location="${DOMAIN_CHAIN_LOCATION}"
+    fi
+    cat "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}_chain.pem"
+    copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem"  "$to_location"
+    if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
+      cat "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_chain.pem.ec"
+      copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem.ec"  "${to_location}" "ec"
+    fi
+  fi
+  # if DOMAIN_KEY_CERT_LOCATION is not blank, then create and copy file.
+  if [[ -n "$DOMAIN_KEY_CERT_LOCATION" ]]; then
+    if [[ "$(dirname "$DOMAIN_KEY_CERT_LOCATION")" == "." ]]; then
+      to_location="${DOMAIN_DIR}/${DOMAIN_KEY_CERT_LOCATION}"
+    else
+      to_location="${DOMAIN_KEY_CERT_LOCATION}"
+    fi
+    cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
+    copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem"  "$to_location"
+    if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
+      cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"
+      copy_file_to_location "private ec key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem.ec" "${to_location}" "ec"
+    fi
+  fi
+  # if DOMAIN_PEM_LOCATION is not blank, then create and copy file.
+  if [[ -n "$DOMAIN_PEM_LOCATION" ]]; then
+    if [[ "$(dirname "$DOMAIN_PEM_LOCATION")" == "." ]]; then
+      to_location="${DOMAIN_DIR}/${DOMAIN_PEM_LOCATION}"
+    else
+      to_location="${DOMAIN_PEM_LOCATION}"
+    fi
+    cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
+    copy_file_to_location "full key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem"  "$to_location"
+    if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
+      cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}.pem.ec"
+      copy_file_to_location "full ec key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem.ec"  "${to_location}" "ec"
+    fi
+  fi
+  # end of copying certs.
+  umask "$ORIG_UMASK"
 }
 
 check_challenge_completion() { # checks with the ACME server if our challenge is OK
@@ -1410,6 +1484,7 @@ help_message() { # print out the help message
 	  -c, --create       Create default config files
 	  -f, --force        Force renewal of cert (overrides expiry checks)
 	  -h, --help         Display this help message and exit
+	  -i, --install      Install certificates and reload service
 	  -q, --quiet        Quiet mode (only outputs on error, success of new cert, or getssl was upgraded)
 	  -Q, --mute         Like -q, but also mute notification about successful upgrade
 	  -r, --revoke   "cert" "key" [CA_server] Revoke a certificate (the cert and key are required)
@@ -2146,6 +2221,8 @@ while [[ -n ${1+defined} ]]; do
      _UPGRADE=1 ;;
     -U | --nocheck)
       _UPGRADE_CHECK=0 ;;
+    -i | --install)
+      _CERT_INSTALL=1 ;;
     -w)
       shift; WORKING_DIR="$1" ;;
     -*)
@@ -2368,6 +2445,14 @@ check_config
 
 # check what dns utils are installed
 find_dns_utils
+
+# if -i|--install install certs, reload and exit
+if [ "0${_CERT_INSTALL}" -eq 1 ]
+then
+  cert_install
+  reload_service
+  graceful_exit
+fi
 
 if [[ -e "$DOMAIN_DIR/FORCE_RENEWAL" ]]; then
   rm -f "$DOMAIN_DIR/FORCE_RENEWAL" || error_exit "problem deleting file $DOMAIN_DIR/FORCE_RENEWAL"
@@ -2647,76 +2732,8 @@ cert_archive
 debug "Certificates obtained and archived locally, will now copy to specified locations"
 
 # copy certs to the correct location (creating concatenated files as required)
-umask 077
+cert_install
 
-copy_file_to_location "domain certificate" "$CERT_FILE" "$DOMAIN_CERT_LOCATION"
-copy_file_to_location "private key" "$DOMAIN_DIR/${DOMAIN}.key" "$DOMAIN_KEY_LOCATION"
-copy_file_to_location "CA certificate" "$CA_CERT" "$CA_CERT_LOCATION"
-if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-  if [[ -n "$DOMAIN_CERT_LOCATION" ]]; then
-    copy_file_to_location "ec domain certificate" \
-                          "${CERT_FILE%.*}.ec.crt" \
-                          "${DOMAIN_CERT_LOCATION}" \
-                          "ec"
-  fi
-  if [[ -n "$DOMAIN_KEY_LOCATION" ]]; then
-    copy_file_to_location "ec private key" \
-                          "$DOMAIN_DIR/${DOMAIN}.ec.key" \
-                          "${DOMAIN_KEY_LOCATION}" \
-                          "ec"
-  fi
-  if [[ -n "$CA_CERT_LOCATION" ]]; then
-    copy_file_to_location "ec CA certificate" \
-                          "${CA_CERT%.*}.ec.crt" \
-                          "${CA_CERT_LOCATION%.*}.crt" \
-                          "ec"
-  fi
-fi
-
-# if DOMAIN_CHAIN_LOCATION is not blank, then create and copy file.
-if [[ -n "$DOMAIN_CHAIN_LOCATION" ]]; then
-  if [[ "$(dirname "$DOMAIN_CHAIN_LOCATION")" == "." ]]; then
-    to_location="${DOMAIN_DIR}/${DOMAIN_CHAIN_LOCATION}"
-  else
-    to_location="${DOMAIN_CHAIN_LOCATION}"
-  fi
-  cat "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}_chain.pem"
-  copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem"  "$to_location"
-  if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cat "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_chain.pem.ec"
-    copy_file_to_location "full chain" "$TEMP_DIR/${DOMAIN}_chain.pem.ec"  "${to_location}" "ec"
-  fi
-fi
-# if DOMAIN_KEY_CERT_LOCATION is not blank, then create and copy file.
-if [[ -n "$DOMAIN_KEY_CERT_LOCATION" ]]; then
-  if [[ "$(dirname "$DOMAIN_KEY_CERT_LOCATION")" == "." ]]; then
-    to_location="${DOMAIN_DIR}/${DOMAIN_KEY_CERT_LOCATION}"
-  else
-    to_location="${DOMAIN_KEY_CERT_LOCATION}"
-  fi
-  cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" > "$TEMP_DIR/${DOMAIN}_K_C.pem"
-  copy_file_to_location "private key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem"  "$to_location"
-  if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}_K_C.pem.ec"
-    copy_file_to_location "private ec key and domain cert pem" "$TEMP_DIR/${DOMAIN}_K_C.pem.ec" "${to_location}" "ec"
-  fi
-fi
-# if DOMAIN_PEM_LOCATION is not blank, then create and copy file.
-if [[ -n "$DOMAIN_PEM_LOCATION" ]]; then
-  if [[ "$(dirname "$DOMAIN_PEM_LOCATION")" == "." ]]; then
-    to_location="${DOMAIN_DIR}/${DOMAIN_PEM_LOCATION}"
-  else
-    to_location="${DOMAIN_PEM_LOCATION}"
-  fi
-  cat "$DOMAIN_DIR/${DOMAIN}.key" "$CERT_FILE" "$CA_CERT" > "$TEMP_DIR/${DOMAIN}.pem"
-  copy_file_to_location "full key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem"  "$to_location"
-  if [[ "$DUAL_RSA_ECDSA" == "true" ]]; then
-    cat "$DOMAIN_DIR/${DOMAIN}.ec.key" "${CERT_FILE%.*}.ec.crt" "${CA_CERT%.*}.ec.crt" > "$TEMP_DIR/${DOMAIN}.pem.ec"
-    copy_file_to_location "full ec key, cert and chain pem" "$TEMP_DIR/${DOMAIN}.pem.ec"  "${to_location}" "ec"
-  fi
-fi
-# end of copying certs.
-umask "$ORIG_UMASK"
 # Run reload command to restart apache / nginx or whatever system
 reload_service
 

--- a/getssl
+++ b/getssl
@@ -220,6 +220,7 @@
 # 2020-03-23 Fix staging server URL in domain template (2.21)
 # 2020-03-30 Fix error message find_dns_utils from over version of "command"
 # 2020-03-30 Fix problems if domain name isn't in lowercase (2.22)
+# 2020-04-16 Add alternative working dirs '/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl'
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
@@ -261,7 +262,7 @@ TEMP_UPGRADE_FILE=""
 TOKEN_USER_ID=""
 USE_SINGLE_ACL="false"
 VALIDATE_VIA_DNS=""
-WORKING_DIR=~/.getssl
+WORKING_DIR_CANDIDATES=('/etc/getssl/' '${SCRIPTDIR}/conf' '${SCRIPTDIR}/.getssl' '~/.getssl')
 _CHECK_ALL=0
 _CREATE_CONFIG=0
 _FORCE_RENEW=0
@@ -2179,6 +2180,7 @@ requires which
 requires openssl
 requires curl
 requires dig nslookup drill host DNS_CHECK_FUNC
+requires dirname
 requires awk
 requires tr
 requires date
@@ -2214,6 +2216,22 @@ AGREEMENT=$(curl --user-agent "$CURL_USERAGENT" -I "${CA}/terms" 2>/dev/null | a
 if [[ -z "$DOMAIN" ]] && [[ ${_CHECK_ALL} -ne 1 ]]; then
   help_message
   graceful_exit
+fi
+
+# Test working directory candidates if unset. Last candidate defaults (~/getssl/)
+if [[ -z "${WORKING_DIR}" ]]
+then
+  SCRIPTDIR="$(cd "$(dirname "$0")"; pwd -P;)"
+  for WDCC in $(seq 0 $((${#WORKING_DIR_CANDIDATES[@]}-1)) )
+  do
+    WORKING_DIR="$(eval echo "${WORKING_DIR_CANDIDATES[$WDCC]}")"
+
+    debug "Testing working dir location '${WORKING_DIR}'"
+    if [[ -s "$WORKING_DIR/getssl.cfg" ]]
+    then
+      break
+    fi
+  done
 fi
 
 # if the "working directory" doesn't exist, then create it.

--- a/test/11-test--install.bats
+++ b/test/11-test--install.bats
@@ -1,0 +1,69 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+}
+
+@test "Check that config files in /etc/getssl works" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+
+    # Create /etc/getssl/$DOMAIN
+    rm -rf /etc/getssl
+    mkdir -p /etc/getssl/${GETSSL_CMD_HOST}
+
+    # Copy the config file to /etc/getssl
+    cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "/etc/getssl/${GETSSL_CMD_HOST}/getssl.cfg"
+    cp "${CODE_DIR}/test/test-config/getssl-etc-template.cfg" "/etc/getssl/getssl.cfg"
+
+    # Run getssl
+    run ${CODE_DIR}/getssl "$GETSSL_CMD_HOST"
+
+    assert_success
+    refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+    refute_output --regexp '[Ee][Rr][Rr][Oo][Rr]'
+    refute_output --regexp '[Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+    assert_line 'Verification completed, obtaining certificate.'
+    assert_line 'Requesting certificate'
+    refute [ -d '$HOME/.getssl' ]
+}
+
+
+@test "Check that --install doesn't call the ACME server" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    CONFIG_FILE="getssl-http01.cfg"
+    #setup_environment
+
+    # Create /etc/getssl/$DOMAIN
+    #mkdir -p /etc/getssl/${GETSSL_CMD_HOST}
+
+    # Copy the config file to /etc/getssl
+    #cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "/etc/getssl/${GETSSL_CMD_HOST}/getssl.cfg"
+    #cp "${CODE_DIR}/test/test-config/getssl-etc-template.cfg" "/etc/getssl/getssl.cfg"
+
+    # Run getssl
+    run ${CODE_DIR}/getssl --install "$GETSSL_CMD_HOST"
+
+    assert_success
+    refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+    refute_output --regexp '[Ee][Rr][Rr][Oo][Rr]'
+    refute_output --regexp '[Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+    refute_line 'Verification completed, obtaining certificate.'
+    refute_line 'Requesting certificate'
+    assert_line --partial 'copying domain certificate to'
+    assert_line --partial 'copying private key to'
+    assert_line --partial 'copying CA certificate to'
+}

--- a/test/11-test--install.bats
+++ b/test/11-test--install.bats
@@ -18,8 +18,10 @@ setup() {
     CONFIG_FILE="getssl-http01.cfg"
     setup_environment
 
+    # Fail if not running in docker and /etc/getssl already exists
+    refute [ -d /etc/getssl ]
+
     # Create /etc/getssl/$DOMAIN
-    rm -rf /etc/getssl
     mkdir -p /etc/getssl/${GETSSL_CMD_HOST}
 
     # Copy the config file to /etc/getssl
@@ -40,19 +42,12 @@ setup() {
 
 
 @test "Check that --install doesn't call the ACME server" {
+    # NOTE that this test depends on the previous test!
     if [ -n "$STAGING" ]; then
         skip "Using staging server, skipping internal test"
     fi
 
     CONFIG_FILE="getssl-http01.cfg"
-    #setup_environment
-
-    # Create /etc/getssl/$DOMAIN
-    #mkdir -p /etc/getssl/${GETSSL_CMD_HOST}
-
-    # Copy the config file to /etc/getssl
-    #cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "/etc/getssl/${GETSSL_CMD_HOST}/getssl.cfg"
-    #cp "${CODE_DIR}/test/test-config/getssl-etc-template.cfg" "/etc/getssl/getssl.cfg"
 
     # Run getssl
     run ${CODE_DIR}/getssl --install "$GETSSL_CMD_HOST"
@@ -66,4 +61,7 @@ setup() {
     assert_line --partial 'copying domain certificate to'
     assert_line --partial 'copying private key to'
     assert_line --partial 'copying CA certificate to'
+
+    # Cleanup previous test
+    rm -rf /etc/getssl
 }

--- a/test/Dockerfile-alpine
+++ b/test/Dockerfile-alpine
@@ -13,8 +13,8 @@ RUN mkdir /etc/nginx/pki/private
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 # Use supervisord to run nginx in the background

--- a/test/Dockerfile-centos6
+++ b/test/Dockerfile-centos6
@@ -14,8 +14,8 @@ COPY ./test/test-config/nginx-ubuntu-no-ssl /etc/nginx/conf.d/default.conf
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 EXPOSE 80 443

--- a/test/Dockerfile-centos7
+++ b/test/Dockerfile-centos7
@@ -15,6 +15,6 @@ COPY ./test/test-config/nginx-centos7.conf /etc/nginx/nginx.conf
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local

--- a/test/Dockerfile-centos7-staging
+++ b/test/Dockerfile-centos7-staging
@@ -18,8 +18,8 @@ COPY ./test/test-config/nginx-centos7.conf /etc/nginx/nginx.conf
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 EXPOSE 80 443

--- a/test/Dockerfile-debian
+++ b/test/Dockerfile-debian
@@ -12,8 +12,8 @@ RUN mkdir /etc/nginx/pki/private
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 # Run eternal loop - for testing

--- a/test/Dockerfile-ubuntu
+++ b/test/Dockerfile-ubuntu
@@ -15,8 +15,8 @@ RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 # Run eternal loop - for testing

--- a/test/Dockerfile-ubuntu-staging
+++ b/test/Dockerfile-ubuntu-staging
@@ -17,7 +17,7 @@ RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/bats-core/bats-assert /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
 RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 

--- a/test/Dockerfile-ubuntu-staging
+++ b/test/Dockerfile-ubuntu-staging
@@ -17,8 +17,8 @@ RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 # Run eternal loop - for testing

--- a/test/Dockerfile-ubuntu16
+++ b/test/Dockerfile-ubuntu16
@@ -17,8 +17,8 @@ COPY ./test/test-config/nginx-ubuntu-no-ssl /etc/nginx/sites-enabled/default
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 # Run eternal loop - for testing

--- a/test/Dockerfile-ubuntu18
+++ b/test/Dockerfile-ubuntu18
@@ -17,8 +17,8 @@ RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone https://github.com/bats-core/bats-core.git /bats-core
-RUN git clone https://github.com/jasonkarns/bats-support /bats-support
-RUN git clone https://github.com/jasonkarns/bats-assert-1 /bats-assert
+RUN git clone https://github.com/bats-core/bats-support /bats-support
+RUN git clone https://github.com/bats-core/bats-assert /bats-assert
 RUN /bats-core/install.sh /usr/local
 
 EXPOSE 80 443

--- a/test/test-config/getssl-etc-template.cfg
+++ b/test/test-config/getssl-etc-template.cfg
@@ -1,0 +1,45 @@
+# vim: filetype=sh
+#
+# This file is read first and is common to all domains
+#
+# Uncomment and modify any variables you need
+# see https://github.com/srvrco/getssl/wiki/Config-variables for details
+#
+# The staging server is best for testing (hence set as default)
+CA="https://acme-staging-v02.api.letsencrypt.org"
+# This server issues full certificates, however has rate limits
+#CA="https://acme-v02.api.letsencrypt.org"
+
+# The agreement that must be signed with the CA, if not defined the default agreement will be used
+#AGREEMENT=""
+
+# Set an email address associated with your account - generally set at account level rather than domain.
+#ACCOUNT_EMAIL="me@example.com"
+ACCOUNT_KEY_LENGTH=4096
+ACCOUNT_KEY="/etc/getssl/account.key"
+
+# Account key and private key types - can be rsa, prime256v1, secp384r1 or secp521r1
+#ACCOUNT_KEY_TYPE="rsa"
+PRIVATE_KEY_ALG="rsa"
+#REUSE_PRIVATE_KEY="true"
+
+# The command needed to reload apache / nginx or whatever you use
+#RELOAD_CMD=""
+
+# The time period within which you want to allow renewal of a certificate
+#  this prevents hitting some of the rate limits.
+# Creating a file called FORCE_RENEWAL in the domain directory allows one-off overrides
+# of this setting
+RENEW_ALLOW="30"
+
+# Define the server type. This can be https, ftp, ftpi, imap, imaps, pop3, pop3s, smtp,
+# smtps_deprecated, smtps, smtp_submission, xmpp, xmpps, ldaps or a port number which
+# will be checked for certificate expiry and also will be checked after
+# an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
+SERVER_TYPE="https"
+CHECK_REMOTE="true"
+
+# Use the following 3 variables if you want to validate via DNS
+#VALIDATE_VIA_DNS="true"
+#DNS_ADD_COMMAND=
+#DNS_DEL_COMMAND=


### PR DESCRIPTION
Two basic improvement I usually patch every time I download last release. Hope others see useful.

Adding alternative working directories while keeping default behavior if no config file is found on them.

Adding -i|--install command to only install and reload service.