### PR TITLE
.gitattributes added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Make all text files lf formatted
+*     text eol=lf


### PR DESCRIPTION
Hello, 

yesterday I wanted to upgrade getssl script. I cloned repository at my notebook with Windows and copied getssl script to my Linux box. But script didn't work at all. After some time I realized Windows made file CRLF formatted.

For this reason I suggest to introduce .gitattributes and tell to git all text files in repository are strictly LF formatted. After this change even clone done on Windows will remain file LF formatted.

Have a nice day!

Jarda 