### PR TITLE
Fix slow fork bomb when directory containing getssl isn't writeable (…

### DIFF
--- a/getssl
+++ b/getssl
@@ -234,6 +234,7 @@
 # 2020-06-06 Fix missing URL_revoke definition when no CA directory suffix (#566)
 # 2020-06-18 Fix CHECK_REMOTE for DUAL_RSA_ECDSA (#570)
 # 2020-07-14 Support space separated SANS (#574) (2.29)
+# 2020-08-31 Fix slow fork bomb when directory containing getssl isn't writeable (#440)
 # ----------------------------------------------------------------------------------------
 
 PROGNAME=${0##*/}
@@ -608,8 +609,12 @@ check_getssl_upgrade() { # check if a more recent version of code is available a
   # use a default of 0 for cases where the latest code has not been obtained.
   if [[ "${latestvdec:-0}" -gt "$localvdec" ]]; then
     if [[ ${_UPGRADE} -eq 1 ]]; then
-      install "$0" "${0}.v${VERSION}"
-      install -m 700 "$TEMP_UPGRADE_FILE" "$0"
+      if ! install "$0" "${0}.v${VERSION}"; then
+	 error_exit "problem renaming old version while updating, check permissions"
+      fi
+      if ! install -m 700 "$TEMP_UPGRADE_FILE" "$0"; then
+	 error_exit "problem installing new version while updating, check permissions"
+      fi
       if [[ ${_MUTE} -eq 0 ]]; then
         echo "Updated getssl from v${VERSION} to v${latestversion}"
         echo "these update notification can be turned off using the -Q option"


### PR DESCRIPTION
…#440)

getssl updets itself by:
- checking for a new version
- if so:
  - download the new one into a tmp location
  - rename the current one to name with version appended
  - rename the tmp file to the current location
  - run the new version
If the renaming fails, the old version gets run, which again downloads, etc.
Now exit if the rename (install command) fails.