### PR TITLE
bugfix: strip comments in drill/dig output when checking txt in dns.

### DIFF
--- a/getssl
+++ b/getssl
@@ -1203,6 +1203,7 @@ if [[ $VALIDATE_VIA_DNS == "true" ]]; then
           elif [[ "$DNS_CHECK_FUNC" == "drill" ]] || [[ "$DNS_CHECK_FUNC" == "dig" ]]; then
             debug "$DNS_CHECK_FUNC" TXT "_acme-challenge.${lower_d}" "@${ns}"
             check_result=$($DNS_CHECK_FUNC TXT "_acme-challenge.${lower_d}" "@${ns}" \
+                           | grep -i "^_acme-challenge.${lower_d}" \
                            | grep 'IN\WTXT'|awk -F'"' '{ print $2}')
           elif [[ "$DNS_CHECK_FUNC" == "host" ]]; then
             check_result=$($DNS_CHECK_FUNC -t TXT "_acme-challenge.${lower_d}" "${ns}" \


### PR DESCRIPTION
The dns query is often being reprinted as a comment as part of the drill/dig output
this caused multiple hits for the grep, making the comparison invalid.
Make sure we strip out comments before we look for the challenge text in the txt record.