### PR TITLE
Correct Makefile indentation in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Makefile is using tabs as indentation, not spaces.

Not only in this project, and also in many other places.