### PR TITLE
Make markdownlint happy about README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Run all tests](https://github.com/srvrco/getssl/workflows/Run%20all%20tests/badge.svg) ![shellcheck](https://github.com/srvrco/getssl/workflows/shellcheck/badge.svg)
 # getssl
+
+![Run all tests](https://github.com/srvrco/getssl/workflows/Run%20all%20tests/badge.svg) ![shellcheck](https://github.com/srvrco/getssl/workflows/shellcheck/badge.svg)
 
 Obtain SSL certificates from the letsencrypt.org ACME server. Suitable
 for automating the process on remote servers.


### PR DESCRIPTION
As `markdownlint` was mentioned here: https://github.com/srvrco/getssl/pull/601#pullrequestreview-537817573

Why not let us make markdownlint happier?

```
README.md:1 MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "![Run all tests](https://githu..."]
README.md:2 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "# getssl"]
```

I know it's not a very formal commit message, hope you won't mind, it's tribute to this Linux kernel commit: https://github.com/torvalds/linux/commit/690b0543a813b0ecfc51b0374c0ce6c8275435f0 :)