### PR TITLE
Fix indentation to two spaces in other_scripts/cpanel_cert_upload

### DIFF
--- a/other_scripts/cpanel_cert_upload
+++ b/other_scripts/cpanel_cert_upload
@@ -14,12 +14,12 @@ rawurlencode() {
   local pos c o
 
   for (( pos=0 ; pos<strlen ; pos++ )); do
-     c=${string:$pos:1}
-     case "$c" in
-        [-_.~a-zA-Z0-9] ) o="${c}" ;;
-        * )               printf -v o '%%%02x' "'$c"
-     esac
-     encoded+="${o}"
+    c=${string:$pos:1}
+    case "$c" in
+      [-_.~a-zA-Z0-9] ) o="${c}" ;;
+      * )               printf -v o '%%%02x' "'$c"
+    esac
+    encoded+="${o}"
   done
   echo "${encoded}"
 }


### PR DESCRIPTION
It should be two spaces, not three or four here 😆 