### PR TITLE
Issue #614: Fix delimiter issues with ${alldomains[]} in create_csr()

### DIFF
--- a/getssl
+++ b/getssl
@@ -895,9 +895,9 @@ create_csr() { # create a csr using a given key (if it doesn't already exist)
     debug "domain csr exists at - $csr_file"
     # check all domains in config are in csr
     if [[ "$IGNORE_DIRECTORY_DOMAIN" == "true" ]]; then
-      read -r -a alldomains <<< "$(echo "$SANS" | sed -e 's/ //g; s/,$//; y/,/\n/' | sort -u)"
+      read -d '\n' -r -a alldomains <<< "$(echo "$SANS" | sed -e 's/ //g; s/,$//; y/,/\n/' | sort -u)"
     else
-      read -r -a alldomains <<< "$(echo "$DOMAIN,$SANS" | sed -e 's/,/ /g; s/ $//; y/ /\n/' | sort -u)"
+      read -d '\n' -r -a alldomains <<< "$(echo "$DOMAIN,$SANS" | sed -e 's/,/ /g; s/ $//; y/ /\n/' | sort -u)"
     fi
     domains_in_csr=$(openssl req -text -noout -in "$csr_file" \
         | sed -n -e 's/^ *Subject: .* CN=\([A-Za-z0-9.-]*\).*$/\1/p; /^ *DNS:.../ { s/ *DNS://g; y/,/\n/; p; }' \
@@ -910,7 +910,7 @@ create_csr() { # create a csr using a given key (if it doesn't already exist)
       fi
     done
     # check all domains in csr are in config
-    if [[ "${alldomains[*]}" != "$domains_in_csr" ]]; then
+    if [[ "$(IFS=$'\n'; echo -n "${alldomains[*]}")" != "$domains_in_csr" ]]; then
       info "existing csr at $csr_file does not have the same domains as the config - re-create-csr"
       _RECREATE_CSR=1
     fi

--- a/getssl
+++ b/getssl
@@ -913,6 +913,8 @@ create_csr() { # create a csr using a given key (if it doesn't already exist)
     if [[ "$(IFS=$'\n'; echo -n "${alldomains[*]}")" != "$domains_in_csr" ]]; then
       info "existing csr at $csr_file does not have the same domains as the config - re-create-csr"
       _RECREATE_CSR=1
+    else
+      test_output "Existing csr at $csr_file contains same domains as the config"
     fi
   fi
   # end of ... check if domain csr exists - if not then create it

--- a/test/u4-create-csr-and-ifs.bats
+++ b/test/u4-create-csr-and-ifs.bats
@@ -1,0 +1,54 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    . /getssl/getssl --source
+    find_dns_utils
+    _RUNNING_TEST=1
+    _USE_DEBUG=0
+}
+
+
+@test "Check create_csr works for multiple domains" {
+    # Create a key
+    csr_key=$(mktemp -t getssl.XXXXXX.key) || error_exit "mktemp failed"
+    csr_file=$(mktemp -t getssl.XXXXXX.csr) || error_exit "mktemp failed"
+    SANS="a.getssl.test,b.getssl.test"
+    SANLIST="subjectAltName=DNS:${SANS//[, ]/,DNS:}"
+    create_key "$ACCOUNT_KEY_TYPE" "$csr_key" "$ACCOUNT_KEY_LENGTH"
+
+    # Create an initial csr
+    run create_csr $csr_file $csr_key
+    assert_success
+
+    # Check that calling create_csr with the same SANSLIST doesn't re-create the csr
+    run create_csr $csr_file $csr_key
+    assert_success
+    refute_line --partial "does not have the same domains"
+
+    # Check that calling create_csr with a different SANSLIST does re-create the csr
+    SANS="a.getssl.test,b.getssl.test,c.getssl.test"
+    SANLIST="subjectAltName=DNS:${SANS//[, ]/,DNS:}"
+    run create_csr $csr_file $csr_key
+    assert_success
+    assert_line --partial "does not contain"
+
+    # Check that calling create_csr with the same SANSLIST, but in a different order does not re-create the csr
+    SANS="c.getssl.test,a.getssl.test,b.getssl.test"
+    SANLIST="subjectAltName=DNS:${SANS//[, ]/,DNS:}"
+    run create_csr $csr_file $csr_key
+    assert_success
+    refute_line --partial "does not contain"
+
+    # Check that removing a domain from the SANSLIST causes the csr to be re-created
+    SANS="c.getssl.test,a.getssl.test"
+    SANLIST="subjectAltName=DNS:${SANS//[, ]/,DNS:}"
+    run create_csr $csr_file $csr_key
+    assert_success
+    assert_line --partial "does not have the same domains as the config"
+}

--- a/test/u4-create-csr-and-ifs.bats
+++ b/test/u4-create-csr-and-ifs.bats
@@ -16,8 +16,8 @@ setup() {
 
 @test "Check create_csr works for multiple domains" {
     # Create a key
-    csr_key=$(mktemp -t getssl.XXXXXX.key) || error_exit "mktemp failed"
-    csr_file=$(mktemp -t getssl.XXXXXX.csr) || error_exit "mktemp failed"
+    csr_key=$(mktemp -t getssl.key.XXXXXX) || error_exit "mktemp failed"
+    csr_file=$(mktemp -t getssl.csr.XXXXXX) || error_exit "mktemp failed"
     SANS="a.getssl.test,b.getssl.test"
     SANLIST="subjectAltName=DNS:${SANS//[, ]/,DNS:}"
     create_key "$ACCOUNT_KEY_TYPE" "$csr_key" "$ACCOUNT_KEY_LENGTH"


### PR DESCRIPTION
- use \n as delimiter for read to array
- use \n as delimiter for comparing SANs