### PR TITLE
Wrong SANS when domain contains a minus character

### DIFF
--- a/getssl
+++ b/getssl
@@ -2578,11 +2578,10 @@ if [[ ${_CREATE_CONFIG} -eq 1 ]]; then
       | openssl x509 2>/dev/null)
     EX_SANS="www.${DOMAIN##\*.}"
     if [[ -n "${EX_CERT}" ]]; then
-      # Putting this inside the EX_SANS line below doesn't work on Centos7
       escaped_d=${DOMAIN/\*/\\\*}
       EX_SANS=$(echo "$EX_CERT" \
         | openssl x509 -noout -text 2>/dev/null| grep "Subject Alternative Name" -A2 \
-        | grep -Eo "DNS:[a-zA-Z 0-9.-\*]*" | sed "s@DNS:${escaped_d}@@g" | grep -v '^$' | cut -c 5-)
+        | grep -Eo "DNS:[a-zA-Z 0-9.\*-]*" | sed "s@DNS:${escaped_d}@@g" | grep -v '^$' | cut -c 5-)
       EX_SANS=${EX_SANS//$'\n'/','}
     fi
     if [[ -n "${EX_SANS}" ]]; then


### PR DESCRIPTION
A regexp to extract 'Subject Alternative Name' doesn't work when the domain use a minus character.

For grep regexp, to lose its special meaning inside brackets, the minus character must be placed in the first or last position in the list.

https://www.gnu.org/software/grep/manual/grep.html#Character-Classes-and-Bracket-Expressions

You can check:
```bash
echo -e 'X509v3 Subject Alternative Name:\n    DNS:a2-b2.net' | grep -Eo "DNS:[a-zA-Z 0-9.-\*]*"
echo -e 'X509v3 Subject Alternative Name:\n    DNS:a2-b2.net' | grep -Eo "DNS:[a-zA-Z 0-9.\*-]*"
```

To test:
Generate the configuration (`getssl -c`) for a domain that have an existing certificate whose subject alternative name use a domain containing a minus character.

I think the comment line can be deleted. I tested on CentOS 7. It seems to work fine.