### PR TITLE
Show error if running in posix mode

### DIFF
--- a/getssl
+++ b/getssl
@@ -250,6 +250,10 @@
 # 2020-12-29 Fix dig SOA lookup (#617)(2.33)
 # ----------------------------------------------------------------------------------------
 
+case :$SHELLOPTS: in
+  *:posix:*)   echo -e "${0##*/}: Running with POSIX mode enabled is not supported" >&2; exit 1;;
+esac
+
 PROGNAME=${0##*/}
 PROGDIR="$(cd "$(dirname "$0")" || exit; pwd -P;)"
 VERSION="2.33"

--- a/getssl
+++ b/getssl
@@ -771,7 +771,9 @@ check_getssl_upgrade() { # check if a more recent version of code is available a
           getssl_versions=("${getssl_versions[@]:1}")
         done
       fi
-      eval "$ORIGCMD"
+      if ! eval "$ORIGCMD"; then
+        error_exit "Running upgraded getssl failed"
+      fi
       graceful_exit
     else
       info ""

--- a/getssl
+++ b/getssl
@@ -248,6 +248,7 @@
 # 2020-12-22 Fixes to get_auth_dns
 # 2020-12-22 Check that dig doesn't return an error (#611)(2.32)
 # 2020-12-29 Fix dig SOA lookup (#617)(2.33)
+# 2021-01-05 Show error if running in POSIX mode (#611)
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in

--- a/test/31-test-posix-error.bats
+++ b/test/31-test-posix-error.bats
@@ -1,0 +1,25 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+}
+
+
+@test "Test that running in POSIX mode shows an error" {
+    # v2.31 uses read to create an array in the get_auth_dns function which causes a parse error in posix mode
+    # Could be re-written to not use this functionality if it causes for required.
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    run bash --posix "${CODE_DIR}/getssl"
+    assert_failure
+    assert_line "getssl: Running with POSIX mode enabled is not supported"
+    check_output_for_errors
+}

--- a/test/32-test-upgrade.bats
+++ b/test/32-test-upgrade.bats
@@ -1,0 +1,78 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+    CURRENT_VERSION=$(awk -F '"' '$1 == "VERSION=" {print $2}' ${CODE_DIR}/getssl)
+    PREVIOUS_VERSION=$(echo ${CURRENT_VERSION} | awk -F. '{ print $1 "." --$2}')
+    run git clone https://github.com/srvrco/getssl.git "$INSTALL_DIR/upgrade-getssl"
+}
+
+
+teardown() {
+    rm -r "$INSTALL_DIR/upgrade-getssl"
+}
+
+
+@test "Test that we are told that a newer version is available" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    cd "$INSTALL_DIR/upgrade-getssl"
+    git checkout tags/v${PREVIOUS_VERSION}
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl.cfg"
+    run "$INSTALL_DIR/upgrade-getssl/getssl" --check-config ${GETSSL_CMD_HOST}
+    assert_success
+    #assert_line "Updated getssl from v${PREVIOUS_VERSION} to v${CURRENT_VERSION}"
+    assert_line "A more recent version (v${CURRENT_VERSION}) of getssl is available, please update"
+    check_output_for_errors
+}
+
+
+@test "Test that we can upgrade to the newer version" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    cd "$INSTALL_DIR/upgrade-getssl"
+    git checkout tags/v${PREVIOUS_VERSION}
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl.cfg"
+    run "$INSTALL_DIR/upgrade-getssl/getssl" --check-config --upgrade ${GETSSL_CMD_HOST}
+    assert_success
+    assert_line "Updated getssl from v${PREVIOUS_VERSION} to v${CURRENT_VERSION}"
+    check_output_for_errors
+}
+
+
+@test "Test that we can upgrade to the newer version when invoking as \"bash ./getssl\"" {
+    # Note that `bash getssl` will fail if the CWD isn't in the PATH and an upgrade occurs
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    cd "$INSTALL_DIR/upgrade-getssl"
+    git checkout tags/v${PREVIOUS_VERSION}
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    cp "${CODE_DIR}/test/test-config/${CONFIG_FILE}" "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl.cfg"
+    run bash ./getssl --check-config --upgrade ${GETSSL_CMD_HOST}
+    assert_success
+    assert_line "Updated getssl from v${PREVIOUS_VERSION} to v${CURRENT_VERSION}"
+    check_output_for_errors
+}

--- a/test/32-test-upgrade.bats
+++ b/test/32-test-upgrade.bats
@@ -9,7 +9,7 @@ load '/getssl/test/test_helper.bash'
 setup() {
     export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
     CURRENT_VERSION=$(awk -F '"' '$1 == "VERSION=" {print $2}' ${CODE_DIR}/getssl)
-    PREVIOUS_VERSION=$(echo ${CURRENT_VERSION} | awk -F. '{ print $1 "." --$2}')
+    PREVIOUS_VERSION=$(echo ${CURRENT_VERSION} | awk -F. '{ print $1 "." $2-1}')
     run git clone https://github.com/srvrco/getssl.git "$INSTALL_DIR/upgrade-getssl"
 }
 

--- a/test/test-config/getssl-http01.cfg
+++ b/test/test-config/getssl-http01.cfg
@@ -27,3 +27,10 @@ RELOAD_CMD="cp /getssl/test/test-config/nginx-ubuntu-ssl ${NGINX_CONFIG} && /get
 # Define the server type and confirm correct certificate is installed
 SERVER_TYPE="https"
 CHECK_REMOTE="true"
+
+if [[ -s "$DOMAIN_DIR/getssl_test_specific.cfg" ]]; then
+    . $DOMAIN_DIR/getssl_test_specific.cfg
+fi
+
+#_USE_DEBUG=1
+#_RUNNING_TEST=1


### PR DESCRIPTION
Running with `sh getssl` starts bash in posix mode, which causes a parse error from v2.31 onwards.  Running with `bash getssl` solves this issue.

Fixes #611 