### PR TITLE
Fix double slash when using root directory with DAVS

### DIFF
--- a/getssl
+++ b/getssl
@@ -886,12 +886,13 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       davsport=$(echo "$to"| awk -F: '{print $5}')
       davslocn=$(echo "$to"| awk -F: '{print $6}')
       davsdirn=$(dirname "$davslocn")
+      davsdirn=$(echo "${davsdirn}/" | sed 's,//,/,g')
       davsfile=$(basename "$davslocn")
       fromdir=$(dirname "$from")
       fromfile=$(basename "$from")
       debug "davs user=$davsuser - pass=$davspass - host=$davshost port=$davsport dir=$davsdirn file=$davsfile"
       debug "from dir=$fromdir  file=$fromfile"
-      curl -u "${davsuser}:${davspass}" -T "${fromdir}/${fromfile}" "https://${davshost}:${davsport}${davsdirn}/${davsfile}"
+      curl -u "${davsuser}:${davspass}" -T "${fromdir}/${fromfile}" "https://${davshost}:${davsport}${davsdirn}${davsfile}"
     else
       if ! mkdir -p "$(dirname "$to")" ; then
         error_exit "cannot create ACL directory $(basename "$to")"


### PR DESCRIPTION
Background:
* DAVS account has the `.well-known/acme-challenge` as its home directory
* For the DAVS account, the token needs thus to be uploaded to `https://my-server.com:1234/TOKEN`
* The current implementation expands the URL to `https://my-server.com:1234//TOKEN` (double slash)
* The double slash causes the upload of the token to fail.

Used sed for substitution for better readability.