### PR TITLE
Update GoDaddy DNS scripts

### DIFF
--- a/dns_scripts/dns_add_godaddy
+++ b/dns_scripts/dns_add_godaddy
@@ -37,4 +37,4 @@ fi
 export GODADDY_KEY
 export GODADDY_SECRET
 
-$GODADDY_SCRIPT -q add "${fulldomain}" "_acme-challenge.${fulldomain}." "${token}"
+$GODADDY_SCRIPT -q add "${fulldomain}" "_acme-challenge" "${token}"

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -155,7 +155,6 @@ if [ -z "$name" ]; then
     echo "'name' parameter is required, see -h" >&2
     exit 3
 fi
-! [[ "$name" =~ [.]$ ]] && name="${name}.${domain}."
 data="$4"
 if [ -z "$data" ]; then
     echo "'data' parameter is required, see -h" >&2
@@ -209,7 +208,7 @@ if [ "$op" = "add" ]; then
 
         url="$API/$domain/records/TXT/$name"
 
-        request='{"data":"'$data'","ttl":'$ttl'}'
+        request='[{"data":"'$data'","ttl":'$ttl'}]'
         [ -n "$DEBUG" ] && cat >&2 <<EOF
 Add request to: $url
 --------
@@ -337,7 +336,7 @@ EOF
 
 eval 'name="$''{name%'"'.$domain.'}"'"'
 
-match="$(printf '"name":"%s","data":"%s","ttl":' "$name" "$data")"
+match="$(printf '"data":"%s","name":"%s","ttl":' "$data" "$name")"
 cmd="$(printf 'echo %s%s%s | grep -v %s%s%s' "'" "$current" "'" "'" "$match" "'")"
 eval 'new="$('"$cmd"')"'
 


### PR DESCRIPTION
Currently, GoDaddy's API requires a list as a body for adding a new record: [reference](https://developer.godaddy.com/doc/endpoint/domains#/v1/recordReplaceTypeName)

Also the API does not accept record names ending with the `.`. To achieve the same result as before it is enough to send just the name of the record without the domain appended to it.

The third change is changing the order of fields when comparing records fetched from GoDaddy. Maybe it would be enough to compare just the names as the ordering of the fields might change again? Or use JSON script to get the proper data. I'm not that familiar with bash scripts to implement that tough. 

@timkimber Please review