### PR TITLE
dns_scripts for Azure CLI

### DIFF
--- a/dns_scripts/Azure-README.txt
+++ b/dns_scripts/Azure-README.txt
@@ -6,16 +6,21 @@ Prerequisites:
 - Azure CLI tools installed - see https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 - Logged in with azure-cli - i.e. azure login
 
-The dns_add_azure and dns_del_azure scripts assume that the following
-environment variables are added to the configuration file:
+Ensure dns_add_azure and dns_del_azure scripts are called when the DNS is validated by modifying the .getssl.cfg:
+
+VALIDATE_VIA_DNS=true
+DNS_ADD_COMMAND=dns_scripts/dns_add_azure # n.b use valid path
+DNS_DEL_COMMAND=dns_scripts/dns_del_azure
+
+The dns_add_azure and dns_del_azure scripts assume that the following environment variables are added to the configuration file:
 
 - AZURE_RESOURCE_GROUP - the name of the resource group that contains the DNS zone 
-- AZURE_ZONE_ID - the name of the DNS zone 
+- AZURE_ZONE_ID - a comma-separated list of valid DNS zones. this allows the same certificate to be used across multiple top-level domains
 - AZURE_SUBSCRIPTION_ID - the name or ID of the subscription that AZURE_RESOURCE_GROUP is part of
 
 Each of these variables can be included in the .getssl.cfg, e.g:
 
 export AZURE_RESOURCE_GROUP=my-resource-group
-export AZURE_ZONE_ID=example.com
+export AZURE_ZONE_ID=example.com,anotherdomain.com
 export AZURE_SUBSCRIPTION_ID=my-azure-subscriptin 
 

--- a/dns_scripts/Azure-README.txt
+++ b/dns_scripts/Azure-README.txt
@@ -1,0 +1,21 @@
+Using Azure for LetsEncrypt domain verification
+
+Guide for using Azure for LetsEncrypt domain verification.
+
+Prerequisites:
+- Azure CLI tools installed - see https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+- Logged in with azure-cli - i.e. azure login
+
+The dns_add_azure and dns_del_azure scripts assume that the following
+environment variables are added to the configuration file:
+
+- AZURE_RESOURCE_GROUP - the name of the resource group that contains the DNS zone 
+- AZURE_ZONE_ID - the name of the DNS zone 
+- AZURE_SUBSCRIPTION_ID - the name or ID of the subscription that AZURE_RESOURCE_GROUP is part of
+
+Each of these variables can be included in the .getssl.cfg, e.g:
+
+export AZURE_RESOURCE_GROUP=my-resource-group
+export AZURE_ZONE_ID=example.com
+export AZURE_SUBSCRIPTION_ID=my-azure-subscriptin 
+

--- a/dns_scripts/dns_add_azure
+++ b/dns_scripts/dns_add_azure
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Set the TXT DNS record with azure-cli
+fulldomain="${1}"
+token="${2}"
+
+if [[ -z "$AZURE_RESOURCE_GROUP" ]]; then
+  echo "AZURE_RESOURCE_GROUP is not set. Unable to set TXT records."
+  exit 2
+fi
+if [[ -z "$AZURE_ZONE_ID" ]]; then
+  echo "AZURE_ZONE_ID is not set. Unable to set TXT records."
+  exit 2
+fi
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then 
+  echo "AZURE_SUBSCRIPTION_ID is not set. Unable to set TXT records."
+  exit 2
+fi
+
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+recordset="_acme-challenge.${fulldomain/.$AZURE_ZONE_ID/}"
+[[ "$recordset" == "_acme-challenge.$fulldomain" ]] && recordset="_acme-challenge"
+az network dns record-set txt add-record -g "$AZURE_RESOURCE_GROUP" -z "$AZURE_ZONE_ID" -n "$recordset" -v "$token"

--- a/dns_scripts/dns_add_azure
+++ b/dns_scripts/dns_add_azure
@@ -16,7 +16,25 @@ if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
   exit 2
 fi
 
+# Determine which zone ID to use from AZURE_ZONE_IDs
+# Convert the comma-separated list of AZURE_ZONE_IDs into an array and loop
+IFS=',' read -ra zone_ids <<< "$AZURE_ZONE_ID"
+for item in "${zone_ids[@]}"; do 
+  # If the full domain ends with the current zone ID
+  [[ "$fulldomain" =~ .*"${item}"$ ]] && zone_id="$item"
+done
+
+if [ -z "$zone_id" ]; then 
+  echo "${fulldomain} does not match any of the zone IDs specified by ${AZURE_ZONE_ID[@]}"
+  exit 2
+fi
+
 az account set --subscription "$AZURE_SUBSCRIPTION_ID"
-recordset="_acme-challenge.${fulldomain/.$AZURE_ZONE_ID/}"
+# Determine the recordset by removing the zone_id from the full domain and prefixing
+# with _acme-challenge.
+recordset="_acme-challenge.${fulldomain/.$zone_id/}"
+# The fulldomain should not be included in the recordset. It is used for subdomains.
+# E.g. domain = *.sub.example.com the recordset is _acme-challenge.sub
+#      domain = example.com the record set is _acme-challenge
 [[ "$recordset" == "_acme-challenge.$fulldomain" ]] && recordset="_acme-challenge"
-az network dns record-set txt add-record -g "$AZURE_RESOURCE_GROUP" -z "$AZURE_ZONE_ID" -n "$recordset" -v "$token"
+az network dns record-set txt add-record -g "$AZURE_RESOURCE_GROUP" -z "$zone_id" -n "$recordset" -v "$token"

--- a/dns_scripts/dns_del_azure
+++ b/dns_scripts/dns_del_azure
@@ -14,7 +14,25 @@ if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
   exit 2
 fi
 
+# Determine which zone ID to use from AZURE_ZONE_IDs
+# Convert the comma-separated list of AZURE_ZONE_IDs into an array and loop
+IFS=',' read -ra zone_ids <<< "$AZURE_ZONE_ID"
+for item in "${zone_ids[@]}"; do 
+  # If the full domain ends with the current zone ID
+  [[ "$fulldomain" =~ .*"${item}"$ ]] && zone_id="$item"
+done
+
+if [ -z "$zone_id" ]; then 
+  echo "${fulldomain} does not match any of the zone IDs specified by ${AZURE_ZONE_ID[@]}"
+  exit 2
+fi
+
 az account set --subscription "$AZURE_SUBSCRIPTION_ID"
-recordset="_acme-challenge.${fulldomain/.$AZURE_ZONE_ID/}"
+# Determine the recordset by removing the zone_id from the full domain and prefixing
+# with _acme-challenge.
+recordset="_acme-challenge.${fulldomain/.$zone_id/}"
+# The fulldomain should not be included in the recordset. It is used for subdomains.
+# E.g. domain = *.sub.example.com the recordset is _acme-challenge.sub
+#      domain = example.com the record set is _acme-challenge
 [[ "$recordset" == "_acme-challenge.$fulldomain" ]] && recordset="_acme-challenge"
-az network dns record-set txt delete --yes -g "$AZURE_RESOURCE_GROUP" -z "$AZURE_ZONE_ID" -n "$recordset"
+az network dns record-set txt delete --yes -g "$AZURE_RESOURCE_GROUP" -z "$zone_id" -n "$recordset"

--- a/dns_scripts/dns_del_azure
+++ b/dns_scripts/dns_del_azure
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Remove the TXT DNS record with azure-cli
+fulldomain="${1}"
+if [[ -z "$AZURE_RESOURCE_GROUP" ]]; then
+  echo "AZURE_RESOURCE_GROUP is not set. Unable to set TXT records."
+  exit 2
+fi
+if [[ -z "$AZURE_ZONE_ID" ]]; then
+  echo "AZURE_ZONE_ID is not set. Unable to set TXT records."
+  exit 2
+fi
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then 
+  echo "AZURE_SUBSCRIPTION_ID is not set. Unable to set TXT records."
+  exit 2
+fi
+
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+recordset="_acme-challenge.${fulldomain/.$AZURE_ZONE_ID/}"
+[[ "$recordset" == "_acme-challenge.$fulldomain" ]] && recordset="_acme-challenge"
+az network dns record-set txt delete --yes -g "$AZURE_RESOURCE_GROUP" -z "$AZURE_ZONE_ID" -n "$recordset"


### PR DESCRIPTION
Sample scripts for using azure-cli to set TXT records. `dns_scripts/Azure-README.txt` contains instructions.