### PR TITLE
Improve the dns scripts for ACME-DNS

### DIFF
--- a/dns_scripts/dns_add_acmedns
+++ b/dns_scripts/dns_add_acmedns
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# ACMEDNS env variables can be set in a config file at domain level
+acme_config="$DOMAIN_DIR/acme-dns.cfg"
+[ -s "$acme_config" ] && . "$acme_config"
+
 # Need to add your API user and key below or set as env variable
 apiuser=${ACMEDNS_API_USER:-''}
 apikey=${ACMEDNS_API_KEY:-''}

--- a/dns_scripts/dns_add_acmedns
+++ b/dns_scripts/dns_add_acmedns
@@ -9,16 +9,18 @@ apiuser=${ACMEDNS_API_USER:-''}
 apikey=${ACMEDNS_API_KEY:-''}
 apisubdomain=${ACMEDNS_SUBDOMAIN:-''}
 
-# This script adds a token to acme-dns.io DNS for the ACME challenge
-# usage dns_add_acme-dns "domain name" "token"
-# return codes are;
+# This script adds a token to an ACME DNS (default to acme-dns.io) for the ACME challenge
+# usage: dns_add_acme-dns "domain name" "token"
+# return codes are:
 # 0 - success
 # 1 - error returned from server
 
 fulldomain="${1}"
 token="${2}"
 
-API='https://auth.acme-dns.io/update'
+# You can set the env var ACMEDNS_URL to use a specific ACME-DNS server
+# Otherwise we use acme-dns.io
+API=${ACMEDNS_URL:-'https://auth.acme-dns.io'}/update
 
 # Check initial parameters
 if [[ -z "$fulldomain" ]]; then

--- a/dns_scripts/dns_add_acmedns
+++ b/dns_scripts/dns_add_acmedns
@@ -54,9 +54,9 @@ resp=$(curl --silent \
   -X POST "${API}" \
   --data "$(generate_post_data)")
 
-echo $resp
 # If adding record failed (returned json includes "error" then print error message
 if [[ "$resp" = *"\"error\""* ]]; then
   echo "Error: DNS challenge not added: unknown error - ${resp}"
   exit 1
 fi
+exit 0

--- a/dns_scripts/dns_del_acmedns
+++ b/dns_scripts/dns_del_acmedns
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
-# Need to add your API user and key below or set as env variable
-apiuser=${ACMEDNS_API_USER:-''}
-apikey=${ACMEDNS_API_KEY:-''}
-apisubdomain=${ACMEDNS_SUBDOMAIN:-''}
 
-# This script adds a token to acme-dns.io DNS for the ACME challenge
-# usage dns_add_acme-dns "domain name" "token"
+# This script aims to delete a token to acme-dns DNS for the ACME challenge
+# However, for now, acme-dns does not provide a delete API service.
+# Its strategy is to update an existing record.
+# So this call isn't relevant and must be neutral.
+
+# usage dns_del_acmedns "domain name" "token"
 # return codes are;
 # 0 - success
 # 1 - error returned from server
 
 fulldomain="${1}"
 token="${2}"
-
-API='https://auth.acme-dns.io/update'
 
 # Check initial parameters
 if [[ -z "$fulldomain" ]]; then
@@ -25,31 +23,6 @@ if [[ -z "$token" ]]; then
   exit 1
 fi
 
-curl_params=(
-  -H "accept: application/json"
-  -H "X-Api-Key: $apikey"
-  -H "X-Api-User: $apiuser"
-  -H 'Content-Type: application/json'
-)
+# nothing to do
 
-generate_post_data()
-{
-  cat <<EOF
-{
-  "subdomain": "$apisubdomain",
-  "txt": "$token"
-}
-EOF
-}
-
-resp=$(curl --silent \
-  "${curl_params[@]}" \
-  -X POST "${API}" \
-  --data "$(generate_post_data)")
-
-echo $resp
-# If adding record failed (returned json includes "error" then print error message
-if [[ "$resp" = *"\"error\""* ]]; then
-  echo "Error: DNS challenge not added: unknown error - ${resp}"
-  exit 1
-fi
+exit 0

--- a/getssl
+++ b/getssl
@@ -2980,7 +2980,7 @@ fi
 # Define defaults for variables not set in the main config.
 ACCOUNT_KEY="${ACCOUNT_KEY:=$WORKING_DIR/account.key}"
 DOMAIN_STORAGE="${DOMAIN_STORAGE:=$WORKING_DIR}"
-DOMAIN_DIR="$DOMAIN_STORAGE/$DOMAIN"
+export DOMAIN_DIR="$DOMAIN_STORAGE/$DOMAIN"
 CERT_FILE="$DOMAIN_DIR/${DOMAIN}.crt"
 FULL_CHAIN="$DOMAIN_DIR/fullchain.crt"
 CA_CERT="$DOMAIN_DIR/chain.crt"


### PR DESCRIPTION
Notably:
  * fix the script dns_del_acmedns
  * Add the ability to set DNS API configuration at domain level
  * Add the ability to choose the ACME-DNS server (for self-hosted servers)

ACME-DNS has an unusual usage comparing to other DNS providers: it provides credential for each registered domain and allow only to update its challenge.