### PR TITLE
Help text: Fix text algining for `--account-id` option

### DIFF
--- a/getssl
+++ b/getssl
@@ -1978,7 +1978,7 @@ help_message() { # print out the help message
 	  -v  --version      Display current version of $PROGNAME
 	  -w working_dir "Working directory"
 	  --preferred-chain "chain" Use an alternate chain for the certificate
-    --account-id      Display account id and exit
+	  --account-id       Display account id and exit
 
 	_EOF_
 }


### PR DESCRIPTION
Changes the small misalignment in the help text line for `--account-id` option:

Before:
![image](https://user-images.githubusercontent.com/811553/180749670-4ff507fd-e9bd-40b8-af70-7a8787150860.png)

After:
![image](https://user-images.githubusercontent.com/811553/180749778-3c65ec0e-a75b-4de8-8d66-dfea284d2e9f.png)
