### PR TITLE
fix continuation \ spacing for Debian Debbuild *.deb make

### DIFF
--- a/getssl.spec
+++ b/getssl.spec
@@ -34,7 +34,7 @@ The %{name} package contains the getssl scripts, crontab files, and logrotate fi
 %{__mkdir_p} %{buildroot}%{_datadir}/getssl/dns_scripts
 %{__mkdir_p} %{buildroot}%{_datadir}/getssl/other_scripts
 %{__make} \
-	DESTDIR=%{buildroot}\
+	DESTDIR=%{buildroot} \
 	install
 install -Dpm 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/cron.d/getssl
 install -Dpm 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/logrotate.d/getssl

--- a/getssl.spec
+++ b/getssl.spec
@@ -13,7 +13,7 @@ Release:          1
 
 URL:              http://github.com/srvrco/getssl/
 Source0:          %{name}-%{version}.tar.gz
-Source1:	  getssl.crontab
+Source1:          getssl.crontab
 Source2:          getssl.logrotate
 BuildArch:        noarch
 


### PR DESCRIPTION
fix continuation \ spacing for Debian and Ubuntu Debbuild *.deb make.  