### PR TITLE
Consistently use /usr/bin/env instead of /bin/bash for portability.

### DIFF
--- a/dns_scripts/dns_add_del_aliyun.sh
+++ b/dns_scripts/dns_add_del_aliyun.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #https://blog.aymar.cn
 #https://protocol.aymar.cn
 PROGNAME=${0##*/}

--- a/dns_scripts/dns_add_dnspod
+++ b/dns_scripts/dns_add_dnspod
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # need to add your email address and key to dnspod below
 key=${DNSPOD_API_KEY:-}

--- a/dns_scripts/dns_add_duckdns
+++ b/dns_scripts/dns_add_duckdns
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # need to add your Token for duckdns below
 token=${DUCKDNS_TOKEN:-}

--- a/dns_scripts/dns_add_godaddy
+++ b/dns_scripts/dns_add_godaddy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2017, 2018 Timothe Litt  litt at acm _dot org
 

--- a/dns_scripts/dns_add_ionos
+++ b/dns_scripts/dns_add_ionos
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/usr/bin/env bash
 #
 # Called as
 #

--- a/dns_scripts/dns_add_joker
+++ b/dns_scripts/dns_add_joker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FULLDOMAIN=$1
 TOKEN=$2

--- a/dns_scripts/dns_add_linode
+++ b/dns_scripts/dns_add_linode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 fulldomain="${1}"
 token="${2}"

--- a/dns_scripts/dns_add_manual
+++ b/dns_scripts/dns_add_manual
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "In the DNS, a new TXT record needs to be created for;"
 echo "_acme-challenge.${1}"

--- a/dns_scripts/dns_add_nsupdate
+++ b/dns_scripts/dns_add_nsupdate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # example of script to add token to local dns using nsupdate
 

--- a/dns_scripts/dns_add_ovh
+++ b/dns_scripts/dns_add_ovh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 domains=($(echo "$1"|sed -e 's/^\(\([a-zA-Z0-9.-]*\?\)\.\)*\([a-zA-Z0-9-]\+\.[a-zA-Z-]\+\)$/"\1" _acme-challenge.\2 \3/g'))
 challenge="$2"

--- a/dns_scripts/dns_add_pdns-mysql
+++ b/dns_scripts/dns_add_pdns-mysql
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # You must either have a suitable ~/.my.cnf containing a user / pass
 # for your mysql / mariadb database, OR you must uncomment the next line

--- a/dns_scripts/dns_add_windows_dns_server
+++ b/dns_scripts/dns_add_windows_dns_server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Windows DNS server using powershell - dnscmd is going to be deprecated 
 # Using Windows Sublinux for executing windows commands

--- a/dns_scripts/dns_del_dnspod
+++ b/dns_scripts/dns_del_dnspod
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # need to add your email address and key to dnspod below
 key=${DNSPOD_API_KEY:-}

--- a/dns_scripts/dns_del_duckdns
+++ b/dns_scripts/dns_del_duckdns
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # need to add your Token for duckdns below
 token=${DUCKDNS_TOKEN:-}

--- a/dns_scripts/dns_del_godaddy
+++ b/dns_scripts/dns_del_godaddy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2017,2018 Timothe Litt  litt at acm _dot org
 

--- a/dns_scripts/dns_del_ionos
+++ b/dns_scripts/dns_del_ionos
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/usr/bin/env bash
 #
 # Called as
 #

--- a/dns_scripts/dns_del_joker
+++ b/dns_scripts/dns_del_joker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FULLDOMAIN=$1
 TOKEN=$2

--- a/dns_scripts/dns_del_linode
+++ b/dns_scripts/dns_del_linode
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 fulldomain="${1}"
 api_url="https://api.linode.com/api/"

--- a/dns_scripts/dns_del_manual
+++ b/dns_scripts/dns_del_manual
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "In the DNS, the following DNS record should be deleted ;"
 echo "_acme-challenge.${1}"

--- a/dns_scripts/dns_del_nsupdate
+++ b/dns_scripts/dns_del_nsupdate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # example of script to remove token from local dns using nsupdate
 

--- a/dns_scripts/dns_del_ovh
+++ b/dns_scripts/dns_del_ovh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 domains=($(echo "$1"|sed -e 's/^\(\([a-zA-Z0-9.-]*\?\)\.\)*\([a-zA-Z0-9-]\+\.[a-zA-Z-]\+\)$/"\1" _acme-challenge.\2 \3/g'))
 #challenge="$2"

--- a/dns_scripts/dns_del_pdns-mysql
+++ b/dns_scripts/dns_del_pdns-mysql
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # You must either have a suitable ~/.my.cnf containing a user / pass
 # for your mysql / mariadb database, OR you must uncomment the next line

--- a/dns_scripts/dns_del_windows_dns_server
+++ b/dns_scripts/dns_del_windows_dns_server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Windows DNS server using powershell - dnscmd is going to be deprecated 
 # Using Windows Sublinux for executing windows commands

--- a/dns_scripts/dns_godaddy
+++ b/dns_scripts/dns_godaddy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2017,2018 Timothe Litt  litt at acm _dot org
 

--- a/other_scripts/cpanel_cert_upload
+++ b/other_scripts/cpanel_cert_upload
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # a simple script for use on shared cpanel server to automatically add the
 # the certificates to cpanel if the uapi function is available


### PR DESCRIPTION
Pretty much what it says on the tin -- most of the scripts use /usr/bin/env instead of directly calling /bin/bash, but a not-insignificant few don't, which breaks platforms that don't have bash in /bin (NetBSD, FreeBSD, and so forth).