### PR TITLE
Add FTP_PORT

### DIFF
--- a/getssl
+++ b/getssl
@@ -1063,6 +1063,7 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       # shellcheck disable=SC2086
       curl ${_NOMETER} -u "${davsuser}:${davspass}" -T "${fromdir}/${fromfile}" "https://${davshost}:${davsport}${davsdirn}${davsfile}"
     elif [[ "${to:0:6}" == "ftpes:" ]] || [[ "${to:0:5}" == "ftps:" ]] ; then
+      # FTPES (FTP over explicit TLS/SSL, port 21) and FTPS (FTP over implicit TLS/SSL, port 990).
       debug "using ftp to copy the file from $from"
       ftpuser=$(echo "$to"| awk -F: '{print $2}')
       ftppass=$(echo "$to"| awk -F: '{print $3}')
@@ -1076,10 +1077,14 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       debug "from dir=$fromdir  file=$fromfile"
       if [[ "${to:0:5}" == "ftps:" ]] ; then
         # shellcheck disable=SC2086
-        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}${ftpdirn}:990/"
+        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}:990/${ftpdirn}/"
+        # shellcheck disable=SC2086
+        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}:990/${ftpdirn}/"
       else
         # shellcheck disable=SC2086
-        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}${ftpdirn}/"
+        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}/${ftpdirn}/"
+        # shellcheck disable=SC2086
+        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}/${ftpdirn}/"
       fi
     else
       if ! mkdir -p "$(dirname "$to")" ; then

--- a/getssl
+++ b/getssl
@@ -319,6 +319,7 @@ DUAL_RSA_ECDSA="false"
 FTP_OPTIONS=""
 FTPS_OPTIONS=""
 FTP_ARGS=""
+FTP_PORT=""
 FULL_CHAIN_INCLUDE_ROOT="false"
 GETSSL_IGNORE_CP_PRESERVE="false"
 HTTP_TOKEN_CHECK_WAIT=0
@@ -1013,7 +1014,7 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       ftpfile=$(basename "$ftplocn")
       fromdir=$(dirname "$from")
       fromfile=$(basename "$from")
-      debug "ftp user=$ftpuser - pass=$ftppass - host=$ftphost dir=$ftpdirn file=$ftpfile"
+      debug "ftp user=$ftpuser - pass=$ftppass - host=$ftphost port=$FTP_PORT dir=$ftpdirn file=$ftpfile"
       debug "from dir=$fromdir  file=$fromfile"
       if [ -n "$FTP_OPTIONS" ]; then
         # Use eval to expand any variables in FTP_OPTIONS
@@ -1021,7 +1022,7 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
         debug "FTP_OPTIONS=$FTP_OPTIONS"
       fi
       $FTP_COMMAND <<- _EOF
-			open $ftphost
+			open $ftphost $FTP_PORT
 			user $ftpuser $ftppass
 			$FTP_OPTIONS
 			cd $ftpdirn
@@ -1038,10 +1039,11 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       ftpfile=$(basename "$ftplocn")
       fromdir=$(dirname "$from")
       fromfile=$(basename "$from")
-      debug "sftp $SFTP_OPTS user=$ftpuser - pass=$ftppass - host=$ftphost dir=$ftpdirn file=$ftpfile"
+      if [ -n "$FTP_PORT" ]; then SFTP_PORT="-P $FTP_PORT"; else SFTP_PORT=""; fi
+      debug "sftp $SFTP_OPTS user=$ftpuser - pass=$ftppass - host=$ftphost port=$FTP_PORT dir=$ftpdirn file=$ftpfile"
       debug "from dir=$fromdir  file=$fromfile"
       # shellcheck disable=SC2086
-      sshpass -p "$ftppass" sftp $SFTP_OPTS "$ftpuser@$ftphost" <<- _EOF
+      sshpass -p "$ftppass" sftp $SFTP_OPTS $SFTP_PORT "$ftpuser@$ftphost" <<- _EOF
 			cd $ftpdirn
 			lcd $fromdir
 			put ./$fromfile
@@ -1064,7 +1066,7 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       curl ${_NOMETER} -u "${davsuser}:${davspass}" -T "${fromdir}/${fromfile}" "https://${davshost}:${davsport}${davsdirn}${davsfile}"
     elif [[ "${to:0:6}" == "ftpes:" ]] || [[ "${to:0:5}" == "ftps:" ]] ; then
       # FTPES (FTP over explicit TLS/SSL, port 21) and FTPS (FTP over implicit TLS/SSL, port 990).
-      debug "using ftp to copy the file from $from"
+      debug "using ${to:0:5} to copy the file from $from"
       ftpuser=$(echo "$to"| awk -F: '{print $2}')
       ftppass=$(echo "$to"| awk -F: '{print $3}')
       ftphost=$(echo "$to"| awk -F: '{print $4}')
@@ -1073,18 +1075,25 @@ copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
       ftpfile=$(basename "$ftplocn")
       fromdir=$(dirname "$from")
       fromfile=$(basename "$from")
-      debug "ftp user=$ftpuser - pass=$ftppass - host=$ftphost dir=$ftpdirn file=$ftpfile"
+
+      SFTP_PORT="";
+      if [ -n "$FTP_PORT" ]; then SFTP_PORT=":${FTP_PORT}"; fi
+      debug "${to:0:5} user=$ftpuser - pass=$ftppass - host=$ftphost port=$FTP_PORT dir=$ftpdirn file=$ftpfile"
       debug "from dir=$fromdir  file=$fromfile"
       if [[ "${to:0:5}" == "ftps:" ]] ; then
+        # if no FTP_PORT is specified, then use default
+        if [ -z "$FTP_PORT" ]; then
+          SFTP_PORT=":990"
+        fi
         # shellcheck disable=SC2086
-        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}:990/${ftpdirn}/"
+        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}${SFTP_PORT}/${ftpdirn}/"
         # shellcheck disable=SC2086
-        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}:990/${ftpdirn}/"
+        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftps://${ftphost}${SFTP_PORT}/${ftpdirn}/"
       else
         # shellcheck disable=SC2086
-        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}/${ftpdirn}/"
+        debug curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}${SFTP_PORT}/${ftpdirn}/"
         # shellcheck disable=SC2086
-        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}/${ftpdirn}/"
+        curl ${_NOMETER} $FTPS_OPTIONS --ftp-ssl --ftp-ssl-reqd -u "${ftpuser}:${ftppass}" -T "${fromdir}/${fromfile}" "ftp://${ftphost}${SFTP_PORT}/${ftpdirn}/"
       fi
     else
       if ! mkdir -p "$(dirname "$to")" ; then

--- a/test/34-ftp-passive.bats
+++ b/test/34-ftp-passive.bats
@@ -155,13 +155,13 @@ EOF3
 
 
 @test "Use ftpes (explicit ssl, port 21) to create challenge file" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
     if [[ ! -f /etc/vsftpd.pem ]]; then
         echo "FAILED: This test requires the previous test to succeed"
         exit 1
-    fi
-
-    if [ -n "$STAGING" ]; then
-        skip "Using staging server, skipping internal test"
     fi
 
     if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
@@ -217,13 +217,13 @@ EOF
 
 
 @test "Use ftps (implicit ssl, port 990) to create challenge file" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
     if [[ ! -f /etc/vsftpd.pem ]]; then
         echo "FAILED: This test requires the previous test to succeed"
         exit 1
-    fi
-
-    if [ -n "$STAGING" ]; then
-        skip "Using staging server, skipping internal test"
     fi
 
     # Restart vsftpd listening on port 990

--- a/test/34-ftp-passive.bats
+++ b/test/34-ftp-passive.bats
@@ -10,7 +10,11 @@ setup() {
     [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
     export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
     if [ -n "${VSFTPD_CONF}" ]; then
-        cp $VSFTPD_CONF ${VSFTPD_CONF}.getssl
+        if [ ! -f "${VSFTPD_CONF}.getssl" ]; then
+            cp $VSFTPD_CONF ${VSFTPD_CONF}.getssl
+        else
+            cp ${VSFTPD_CONF}.getssl $VSFTPD_CONF
+        fi
 
         # enable passive and disable active mode
         # https://www.pixelstech.net/article/1364817664-FTP-active-mode-and-passive-mode
@@ -18,10 +22,7 @@ setup() {
 pasv_enable=YES
 pasv_max_port=10100
 pasv_min_port=10090
-connect_from_port_20=NO
 _FTP
-
-        ${CODE_DIR}/test/restart-ftpd start
     fi
 }
 
@@ -44,6 +45,8 @@ teardown() {
         mkdir -p /var/www/html/.well-known/acme-challenge
     fi
 
+    ${CODE_DIR}/test/restart-ftpd start
+
     NEW_FTP="false"
     if [[ "$(ftp -? 2>&1 | head -1 | cut -c-6)" == "usage:" ]]; then
         NEW_FTP="true"
@@ -57,8 +60,11 @@ teardown() {
     setup_environment
     init_getssl
 
+    # The DOMAIN_PEM_LOCATION creates a *signed* certificate for the ftps/ftpes tests
     cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
 ACL="ftp:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+DOMAIN_PEM_LOCATION=/etc/vsftpd.pem
+CA_CERT_LOCATION=/etc/cacert.pem
 EOF
     if [[ "$FTP_PASSIVE_DEFAULT" == "false" ]]; then
         if [[ "$NEW_FTP" == "true" ]]; then
@@ -97,6 +103,8 @@ EOF4
     if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
         mkdir -p /var/www/html/.well-known/acme-challenge
     fi
+
+    ${CODE_DIR}/test/restart-ftpd start
 
     NEW_FTP="false"
     if [[ "$(ftp -? 2>&1 | head -1 | cut -c-6)" == "usage:" ]]; then
@@ -142,5 +150,130 @@ EOF3
     else
         assert_line --partial "Entering Passive Mode"
     fi
+    check_output_for_errors
+}
+
+
+@test "Use ftpes (explicit ssl, port 21) to create challenge file" {
+    if [[ ! -f /etc/vsftpd.pem ]]; then
+        echo "FAILED: This test requires the previous test to succeed"
+        exit 1
+    fi
+
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
+        mkdir -p /var/www/html/.well-known/acme-challenge
+    fi
+
+    # Restart vsftpd with ssl enabled
+    cat <<- _FTP >> $VSFTPD_CONF
+connect_from_port_20=NO
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_data_ssl=NO
+force_local_logins_ssl=NO
+ssl_tlsv1=YES
+ssl_sslv2=NO
+ssl_sslv3=NO
+require_ssl_reuse=NO
+ssl_ciphers=HIGH
+rsa_cert_file=/etc/vsftpd.pem
+rsa_private_key_file=/etc/vsftpd.pem
+_FTP
+    ${CODE_DIR}/test/restart-ftpd start
+
+    # Always change ownership and permissions in case previous tests created the directories as root
+    chgrp -R www-data /var/www/html/.well-known
+    chmod -R g+w /var/www/html/.well-known
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+
+    # Verbose output is needed so the test assertion passes
+    # On Ubuntu 14 and 18 curl errors with "unable to get issuer certificate" so disable cert check using "-k"
+    if [[ "$GETSSL_OS" == "ubuntu14" || "$GETSSL_OS" == "ubuntu18" ]]; then
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+    ACL="ftpes:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+    FTPS_OPTIONS="--cacert /etc/cacert.pem -v -k"
+EOF
+    else
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftpes:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v"
+EOF
+    fi
+
+    create_certificate
+    assert_success
+    # assert_line --partial "SSL connection using TLSv1.3"
+    assert_line --partial "200 PROT now Private"
+
+    check_output_for_errors
+}
+
+
+@test "Use ftps (implicit ssl, port 990) to create challenge file" {
+    if [[ ! -f /etc/vsftpd.pem ]]; then
+        echo "FAILED: This test requires the previous test to succeed"
+        exit 1
+    fi
+
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    # Restart vsftpd listening on port 990
+    cat <<- _FTP >> $VSFTPD_CONF
+implicit_ssl=YES
+listen_port=990
+connect_from_port_20=NO
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_data_ssl=NO
+force_local_logins_ssl=NO
+ssl_tlsv1=YES
+ssl_sslv2=NO
+ssl_sslv3=NO
+require_ssl_reuse=NO
+ssl_ciphers=HIGH
+rsa_cert_file=/etc/vsftpd.pem
+rsa_private_key_file=/etc/vsftpd.pem
+_FTP
+    ${CODE_DIR}/test/restart-ftpd start
+
+    if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
+        mkdir -p /var/www/html/.well-known/acme-challenge
+    fi
+
+    # Always change ownership and permissions in case previous tests created the directories as root
+    chgrp -R www-data /var/www/html/.well-known
+    chmod -R g+w /var/www/html/.well-known
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+
+    # Verbose output is needed so the test assertion passes
+    # On Ubuntu 14 and 18 curl errors with "unable to get issuer certificate" so disable cert check using "-k"
+    # as I don't have time to fix
+    if [[ "$GETSSL_OS" == "ubuntu14" || "$GETSSL_OS" == "ubuntu18" ]]; then
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftps:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v -k"
+EOF
+    else
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftps:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v"
+EOF
+    fi
+
+    create_certificate
+    assert_success
+    assert_line --partial "200 PROT now Private"
     check_output_for_errors
 }

--- a/test/34-ftp-ports.bats
+++ b/test/34-ftp-ports.bats
@@ -38,13 +38,13 @@ teardown() {
 
 
 @test "Use ftpes, FTP_PORT=1001 (explicit ssl, port 1001) to create challenge file" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
     if [[ ! -f /etc/vsftpd.pem ]]; then
         echo "FAILED: This test requires the previous test to succeed"
         exit 1
-    fi
-
-    if [ -n "$STAGING" ]; then
-        skip "Using staging server, skipping internal test"
     fi
 
     if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
@@ -103,13 +103,13 @@ EOF
 
 
 @test "Use ftps, FTP_PORT=2002 (implicit ssl, port 2002) to create challenge file" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
     if [[ ! -f /etc/vsftpd.pem ]]; then
         echo "FAILED: This test requires the previous test to succeed"
         exit 1
-    fi
-
-    if [ -n "$STAGING" ]; then
-        skip "Using staging server, skipping internal test"
     fi
 
     # Restart vsftpd listening on port 990

--- a/test/34-ftp-ports.bats
+++ b/test/34-ftp-ports.bats
@@ -1,0 +1,167 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+    if [ -n "${VSFTPD_CONF}" ]; then
+        if [ ! -f "${VSFTPD_CONF}.getssl" ]; then
+            cp $VSFTPD_CONF ${VSFTPD_CONF}.getssl
+        else
+            cp ${VSFTPD_CONF}.getssl $VSFTPD_CONF
+        fi
+
+        # enable passive and disable active mode
+        # https://www.pixelstech.net/article/1364817664-FTP-active-mode-and-passive-mode
+        cat <<- _FTP >> $VSFTPD_CONF
+pasv_enable=YES
+pasv_max_port=10100
+pasv_min_port=10090
+_FTP
+    fi
+}
+
+
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+    if [ -n "${VSFTPD_CONF}" ]; then
+        cp ${VSFTPD_CONF}.getssl $VSFTPD_CONF
+        ${CODE_DIR}/test/restart-ftpd stop
+    fi
+}
+
+
+
+@test "Use ftpes, FTP_PORT=1001 (explicit ssl, port 1001) to create challenge file" {
+    if [[ ! -f /etc/vsftpd.pem ]]; then
+        echo "FAILED: This test requires the previous test to succeed"
+        exit 1
+    fi
+
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
+        mkdir -p /var/www/html/.well-known/acme-challenge
+    fi
+
+    # Restart vsftpd with ssl enabled
+    cat <<- _FTP >> $VSFTPD_CONF
+connect_from_port_20=NO
+listen_port=1001
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_data_ssl=NO
+force_local_logins_ssl=NO
+ssl_tlsv1=YES
+ssl_sslv2=NO
+ssl_sslv3=NO
+require_ssl_reuse=NO
+ssl_ciphers=HIGH
+rsa_cert_file=/etc/vsftpd.pem
+rsa_private_key_file=/etc/vsftpd.pem
+_FTP
+    ${CODE_DIR}/test/restart-ftpd start
+
+    # Always change ownership and permissions in case previous tests created the directories as root
+    chgrp -R www-data /var/www/html/.well-known
+    chmod -R g+w /var/www/html/.well-known
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+
+    # Verbose output is needed so the test assertion passes
+    # On Ubuntu 14 and 18 curl errors with "unable to get issuer certificate" so disable cert check using "-k"
+    if [[ "$GETSSL_OS" == "ubuntu14" || "$GETSSL_OS" == "ubuntu18" ]]; then
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+    ACL="ftpes:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+    FTPS_OPTIONS="--cacert /etc/cacert.pem -v -k"
+    FTP_PORT=1001
+EOF
+    else
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftpes:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v"
+FTP_PORT=1001
+EOF
+    fi
+
+    create_certificate
+    assert_success
+    # assert_line --partial "SSL connection using TLSv1.3"
+    assert_line --partial "200 PROT now Private"
+
+    check_output_for_errors
+}
+
+
+@test "Use ftps, FTP_PORT=2002 (implicit ssl, port 2002) to create challenge file" {
+    if [[ ! -f /etc/vsftpd.pem ]]; then
+        echo "FAILED: This test requires the previous test to succeed"
+        exit 1
+    fi
+
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    # Restart vsftpd listening on port 990
+    cat <<- _FTP >> $VSFTPD_CONF
+implicit_ssl=YES
+listen_port=2002
+connect_from_port_20=NO
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_data_ssl=NO
+force_local_logins_ssl=NO
+ssl_tlsv1=YES
+ssl_sslv2=NO
+ssl_sslv3=NO
+require_ssl_reuse=NO
+ssl_ciphers=HIGH
+rsa_cert_file=/etc/vsftpd.pem
+rsa_private_key_file=/etc/vsftpd.pem
+_FTP
+    ${CODE_DIR}/test/restart-ftpd start
+
+    if [[ ! -d /var/www/html/.well-known/acme-challenge ]]; then
+        mkdir -p /var/www/html/.well-known/acme-challenge
+    fi
+
+    # Always change ownership and permissions in case previous tests created the directories as root
+    chgrp -R www-data /var/www/html/.well-known
+    chmod -R g+w /var/www/html/.well-known
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+
+    # Verbose output is needed so the test assertion passes
+    # On Ubuntu 14 and 18 curl errors with "unable to get issuer certificate" so disable cert check using "-k"
+    # as I don't have time to fix
+    if [[ "$GETSSL_OS" == "ubuntu14" || "$GETSSL_OS" == "ubuntu18" ]]; then
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftps:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v -k"
+FTP_PORT=2002
+EOF
+    else
+        cat <<- EOF > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+ACL="ftps:ftpuser:ftpuser:${GETSSL_CMD_HOST}:/var/www/html/.well-known/acme-challenge"
+FTPS_OPTIONS="--cacert /etc/cacert.pem -v"
+FTP_PORT=2002
+EOF
+    fi
+
+    create_certificate
+    assert_success
+    assert_line --partial "200 PROT now Private"
+    check_output_for_errors
+}

--- a/test/restart-ftpd
+++ b/test/restart-ftpd
@@ -7,9 +7,14 @@ else
 fi
 
 if [ "$GETSSL_OS" = "alpine" ]; then
-    killall -HUP vsftpd
+    # Switch to supervisorctl as killall -HUP won't change the listen port
+    supervisorctl restart vsftpd:
 elif [[ "$GETSSL_OS" == "centos"[78] || "$GETSSL_OS" == "rockylinux"* ]]; then
-    pgrep vsftpd | head -1 | xargs kill -HUP
+    # Hard restart the service as using -HUP won't change the listening port
+    if pgrep vsftpd; then
+      pgrep vsftpd | head -1 | xargs kill
+      vsftpd 3>&- 4>&-
+    fi
 elif [[ "$GETSSL_OS" == "centos6" ]]; then
     service vsftpd "$arg" 3>&- 4>&-
 else

--- a/test/run-test.cmd
+++ b/test/run-test.cmd
@@ -77,6 +77,8 @@ docker run -it ^
   --network-alias j.%OS%.getssl.test ^
   --network-alias k.%OS%.getssl.test ^
   --network-alias wild-%ALIAS% ^
+  --hostname getssl-%OS% ^
+  --dns 8.8.8.8 ^
   --name getssl-%OS% ^
   getssl-%OS% ^
   %COMMAND%

--- a/test/test-config/alpine-supervisord.conf
+++ b/test/test-config/alpine-supervisord.conf
@@ -1,3 +1,12 @@
+[unix_http_server]
+file=/etc/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///etc/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 nodaemon=false
 logfile=/tmp/supervisord.log


### PR DESCRIPTION
Add support for FTP_PORT to specify a non-standard port for `ftp`, `sftp`, `ftps` or `ftpes`
Add tests for `ftps` and `ftpes`
Fixes #758 