### PR TITLE
Update Cloudflare documentation

### DIFF
--- a/dns_scripts/Cloudflare-README.md
+++ b/dns_scripts/Cloudflare-README.md
@@ -38,14 +38,18 @@ Cloudflare provides a template for creating an API Token with access to edit
 zone records.  Tokens must be created with at least '**DNS:Edit** permissions
 for the domain to add/delete records.
 
-The API requires higher privileges to be able to list zones, therefore this
-method also requires the **Zone ID** from the Overview tab in the Cloudflare
-Dashboard.
-
 Set the following options in the domain-specific `getssl.cfg`
 
 ```
 export CF_API_TOKEN="..."
+```
+
+By default, the associated **Zone ID** is searched automatically. However, it
+is also possible to configure the Zone ID manually. This might be necessary
+if there are a lot of zones. You can find the Zone ID at the Overview tab in
+the Cloudflare Dashboard.
+
+```
 export CF_ZONE_ID="..."
 ```
 


### PR DESCRIPTION
_**Important**: Someone should test and review this with an old (existing) Cloudflare account/token!_

It seems that the documentation for Cloudflare is outdated. There's no special privileges required to list zones.

What I've done:

1. Registered a new Cloudflare account.
2. Added a domain to my account. (Free Plan)
3. Created a new API token with only `DNS:Edit`.
4. Called the add/del scripts…

```bash
CF_API_TOKEN=MYSECRETTOKEN ./dns_scripts/dns_add_cloudflare test.example.net 1337
CF_API_TOKEN=MYSECRETTOKEN ./dns_scripts/dns_del_cloudflare test.example.net 1337
```

No error, the record will be created/deleted at Cloudflare without any problems.