### PR TITLE
Update Linode API to V4

### DIFF
--- a/dns_scripts/dns_add_linode
+++ b/dns_scripts/dns_add_linode
@@ -19,25 +19,37 @@ if [[ -z "$LINODE_KEY" ]]; then
   exit 1
 fi
 
-domain_root=${fulldomain#*.}
-domain=${fulldomain%.$domain_root}
-txtname="_acme-challenge.$domain"
-
-# Get Domain ID
+# Get Domain List
 response=$(curl --silent ${api_url}/domains \
   -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
-domain_id=$(echo "$response" |  jq ".data[] | select (.domain==\"$domain_root\") | .id")
-if [[ $domain_id == "" ]]; then
+
+# Get Domain ID for longest match
+domain_root="$fulldomain"
+domain=""
+
+while [[ "$domain_root" == *.* ]] ; do
+	domain_id=$(echo "$response" | jq ".data[]? | select (.domain==\"$domain_root\") | .id")
+	if [[ "$domain_id" != "" ]] ; then
+		break
+	fi
+	domain_root=${domain_root#*.}
+	domain=${fulldomain%.$domain_root}
+done
+
+if [[ "$domain_id" == "" ]]; then
   echo "Failed to fetch DomainID"
   exit 1
 fi
 
+txtname="_acme-challenge${domain:+.$domain}"
+
 # Create TXT record
+
 response=$(curl --silent -X POST ${api_url}/domains/${domain_id}/records \
   -H "Content-Type: application/json" -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}" \
   -d '{"type": "TXT", "name": "'${txtname}'", "target": "'$token'", "ttl_sec": 30}')
 errors=$(echo "$response" | jq ".errors[]?.reason")
-if [[ $errors != "" ]]; then
+if [[ "$errors" != "" ]]; then
     echo "Something went wrong: $errors"
     exit 1
 fi

--- a/dns_scripts/dns_add_linode
+++ b/dns_scripts/dns_add_linode
@@ -2,7 +2,7 @@
 
 fulldomain="${1}"
 token="${2}"
-api_url="https://api.linode.com/api/"
+api_url="https://api.linode.com/v4"
 api_key=${LINODE_KEY:-''}
 
 # Verify that required parameters are set
@@ -19,26 +19,25 @@ if [[ -z "$LINODE_KEY" ]]; then
   exit 1
 fi
 
-domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF}')
+domain_root=${fulldomain#*.}
 domain=${fulldomain%.$domain_root}
 txtname="_acme-challenge.$domain"
 
 # Get Domain ID
-response=$(curl --silent -X POST "$api_url" \
-  -H "Accept: application/json" -H "User-Agent: getssl/0.1" -H "application/x-www-form-urlencoded" \
-  -d "api_key=${api_key}&api_action=domain.list" )
-domain_id=$(echo "$response" | egrep -o "{\"DOMAIN\":\"$domain_root\".*\"DOMAINID\":([0-9]+)" | egrep -o "[0-9]+$")
+response=$(curl --silent ${api_url}/domains \
+  -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
+domain_id=$(echo "$response" |  jq ".data[] | select (.domain==\"$domain_root\") | .id")
 if [[ $domain_id == "" ]]; then
   echo "Failed to fetch DomainID"
   exit 1
 fi
 
 # Create TXT record
-response=$(curl --silent -X POST "$api_url" \
-  -H "Accept: application/json" -H "User-Agent: getssl/0.1" -H "application/x-www-form-urlencoded" \
-  -d "api_key=$api_key&api_action=domain.resource.create&DomainID=$domain_id&Type=TXT&Name=$txtname&Target=$token" )
-errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
-if [[ $errors != "\"ERRORARRAY\":[]" ]]; then
+response=$(curl --silent -X POST ${api_url}/domains/${domain_id}/records \
+  -H "Content-Type: application/json" -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}" \
+  -d '{"type": "TXT", "name": "'${txtname}'", "target": "'$token'", "ttl_sec": 30}')
+errors=$(echo "$response" | jq ".errors[]?.reason")
+if [[ $errors != "" ]]; then
     echo "Something went wrong: $errors"
     exit 1
 fi

--- a/dns_scripts/dns_del_linode
+++ b/dns_scripts/dns_del_linode
@@ -14,24 +14,35 @@ if [[ -z "$LINODE_KEY" ]]; then
   exit 1
 fi
 
-domain_root=${fulldomain#*.}
-domain=${fulldomain%.$domain_root}
-txtname="_acme-challenge.$domain"
-
-# Get Domain ID
+# Get Domain List
 response=$(curl --silent ${api_url}/domains \
   -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
-domain_id=$(echo "$response" |  jq ".data[] | select (.domain==\"$domain_root\") | .id")
-if [[ $domain_id == "" ]]; then
+
+# Get Domain ID for longest match
+domain_root="$fulldomain"
+domain=""
+
+while [[ "$domain_root" == *.* ]] ; do
+	domain_id=$(echo "$response" | jq ".data[]? | select (.domain==\"$domain_root\") | .id")
+	if [[ "$domain_id" != "" ]] ; then
+		break
+	fi
+	domain_root=${domain_root#*.}
+	domain=${fulldomain%.$domain_root}
+done
+
+if [[ "$domain_id" == "" ]]; then
   echo "Failed to fetch DomainID"
   exit 1
 fi
+
+txtname="_acme-challenge${domain:+.$domain}"
 
 # Get Resource ID
 response=$(curl --silent ${api_url}/domains/${domain_id}/records \
   -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
 resource_id=$(echo "$response" |  jq ".data[] | select (.name==\"$txtname\") | .id")
-if [[ $resource_id == "" ]]; then
+if [[ "$resource_id" == "" ]]; then
   echo "Failed to fetch ResourceID"
   exit 1
 fi
@@ -40,7 +51,7 @@ fi
 response=$(curl --silent -X DELETE ${api_url}/domains/${domain_id}/records/${resource_id} \
   -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
 errors=$(echo "$response" | jq ".errors[]?.reason")
-if [[ $errors != "" ]]; then
+if [[ "$errors" != "" ]]; then
     echo "Something went wrong: $errors"
     exit 1
 fi

--- a/dns_scripts/dns_del_linode
+++ b/dns_scripts/dns_del_linode
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 fulldomain="${1}"
-api_url="https://api.linode.com/api/"
+api_url="https://api.linode.com/v4"
 api_key=${LINODE_KEY:-''}
 
 # Verify that required parameters are set
@@ -14,36 +14,33 @@ if [[ -z "$LINODE_KEY" ]]; then
   exit 1
 fi
 
-domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF}')
+domain_root=${fulldomain#*.}
 domain=${fulldomain%.$domain_root}
 txtname="_acme-challenge.$domain"
 
 # Get Domain ID
-response=$(curl --silent -X POST "$api_url" \
-  -H "Accept: application/json" -H "User-Agent: getssl/0.1" -H "application/x-www-form-urlencoded" \
-  -d "api_key=${api_key}&api_action=domain.list" )
-domain_id=$(echo "$response" | egrep -o "{\"DOMAIN\":\"$domain_root\".*\"DOMAINID\":([0-9]+)" | egrep -o "[0-9]+$")
+response=$(curl --silent ${api_url}/domains \
+  -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
+domain_id=$(echo "$response" |  jq ".data[] | select (.domain==\"$domain_root\") | .id")
 if [[ $domain_id == "" ]]; then
   echo "Failed to fetch DomainID"
   exit 1
 fi
 
 # Get Resource ID
-response=$(curl --silent -X POST "$api_url" \
-  -H "Accept: application/json" -H "User-Agent: getssl/0.1" -H "application/x-www-form-urlencoded" \
-  -d "api_key=${api_key}&api_action=domain.resource.list&DomainID=$domain_id" )
-resource_id=$(echo "$response" | egrep -o "\"RESOURCEID\":[0-9]+,\"TYPE\":\"TXT\",\"NAME\":\"$txtname\"" | egrep -o "\"RESOURCEID\":[0-9]+" | egrep -o "[0-9]+$")
+response=$(curl --silent ${api_url}/domains/${domain_id}/records \
+  -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
+resource_id=$(echo "$response" |  jq ".data[] | select (.name==\"$txtname\") | .id")
 if [[ $resource_id == "" ]]; then
   echo "Failed to fetch ResourceID"
   exit 1
 fi
 
 # Delete TXT record
-response=$(curl --silent -X POST "$api_url" \
-  -H "Accept: application/json" -H "User-Agent: getssl/0.1" -H "application/x-www-form-urlencoded" \
-  -d "api_key=$api_key&api_action=domain.resource.delete&DomainID=$domain_id&ResourceID=$resource_id" )
-errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
-if [[ $errors != "\"ERRORARRAY\":[]" ]]; then
+response=$(curl --silent -X DELETE ${api_url}/domains/${domain_id}/records/${resource_id} \
+  -H "User-Agent: getssl/0.1" -H "Authorization: Bearer ${api_key}")
+errors=$(echo "$response" | jq ".errors[]?.reason")
+if [[ $errors != "" ]]; then
     echo "Something went wrong: $errors"
     exit 1
 fi


### PR DESCRIPTION
Fixes #831

These changes update the Linode DNS scripts to use the current V4 API.

In addition, the domain matching has been corrected and improved, by searching the list of returned domains for the longest matching domain. This correctly handles situations where the domain name has more than two components (such as `domain.co.uk`), and also where a sub-domain is also stored on the same account.