### PR TITLE
Allow SERVER_TYPE=postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ these are available in getssl to check if the certificate is installed correctly
 | xmpp             | 5222 | StartTLS     |
 | xmpps            | 5269 |              |
 | ldaps            | 636  |              |
+| postgres         | 5432 |              |
 | port number      |      |              |
 
 ## Revoke a certificate

--- a/getssl
+++ b/getssl
@@ -2438,6 +2438,9 @@ set_server_type() { # uses SERVER_TYPE to set REMOTE_PORT and REMOTE_EXTRA
     REMOTE_PORT=5269
   elif [[ ${SERVER_TYPE} == "ldaps" ]]; then
     REMOTE_PORT=636
+  elif [[ ${SERVER_TYPE} == "postgres" ]]; then
+    REMOTE_PORT=5432
+    REMOTE_EXTRA="-starttls postgres"
   elif [[ ${SERVER_TYPE} =~ ^[0-9]+$ ]]; then
     REMOTE_PORT=${SERVER_TYPE}
   else


### PR DESCRIPTION
Verifying PostgreSQL certificates requires setting the protocol type for s_client as it is not plain TLS, but behaving more like StartTLS in other protocols.