### PR TITLE
Add Hetzner DNS scripts

### DIFF
--- a/dns_scripts/dns_add_hetzner
+++ b/dns_scripts/dns_add_hetzner
@@ -28,21 +28,23 @@ fi
 # Get Zone ID if not set
 if [ -z "$HETZNER_ZONE_ID" ] ; then
   zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+  if [ -z "$zone_id" == "null" ] ; then
+    echo "Zone ID not found"
+    exit 1
+  fi
 fi
 
-# domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF FS}')
-# domain=${fulldomain%.$domain_root}
 txtname="_acme-challenge.$fulldomain."
 
-echo $zone_id
 # Create TXT record
 response=$(curl --silent -X POST "$api_url/records" \
      -H 'Content-Type: application/json' \
      -H "Auth-API-Token: $api_key" \
-     -d '{"value": "'$token'","ttl": 60,"type": "TXT","name": "_acme-challenge.'$fulldomain'.","zone_id": "'$zone_id'"}')
-echo "$response"
-# errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
-# if [[ $errors != "\"ERRORARRAY\":[]" ]]; then
-#     echo "Something went wrong: $errors"
-#     exit 1
-# fi
+     -d '{"value": "'$token'","ttl": 60,"type": "TXT","name": "_acme-challenge.'$fulldomain'.","zone_id": "'$zone_id'"}' \
+     -o /dev/null -w '%{http_code}')
+
+if [  "$response" != "200" ] ; then
+  echo "Record not created"
+  echo "Response code: $response"
+  exit 1
+fi

--- a/dns_scripts/dns_add_hetzner
+++ b/dns_scripts/dns_add_hetzner
@@ -20,15 +20,15 @@ if [[ -z "$HETZNER_KEY" ]]; then
   echo "HETZNER_KEY variable not set"
   exit 1
 fi
-if [ -z "$HETZNER_ZONE_ID" ] && [ -z "$HETZNER_ZONE_NAME" ] ; then
+if [[ -z "$HETZNER_ZONE_ID" && -z "$HETZNER_ZONE_NAME" ]] ; then
   echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
   exit 1
 fi
 
 # Get Zone ID if not set
-if [ -z "$HETZNER_ZONE_ID" ] ; then
-  zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
-  if [ -z "$zone_id" == "null" ] ; then
+if [[ -z "$HETZNER_ZONE_ID" ]] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$zone_name" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+  if [[ "$zone_id" == "null" ]] ; then
     echo "Zone ID not found"
     exit 1
   fi
@@ -40,10 +40,10 @@ txtname="_acme-challenge.$fulldomain."
 response=$(curl --silent -X POST "$api_url/records" \
      -H 'Content-Type: application/json' \
      -H "Auth-API-Token: $api_key" \
-     -d '{"value": "'$token'","ttl": 60,"type": "TXT","name": "_acme-challenge.'$fulldomain'.","zone_id": "'$zone_id'"}' \
+     -d '{"value": "'"$token"'","ttl": 60,"type": "TXT","name": "'"$txtname"'","zone_id": "'"$zone_id"'"}' \
      -o /dev/null -w '%{http_code}')
 
-if [  "$response" != "200" ] ; then
+if [[ "$response" != "200" ]] ; then
   echo "Record not created"
   echo "Response code: $response"
   exit 1

--- a/dns_scripts/dns_add_hetzner
+++ b/dns_scripts/dns_add_hetzner
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="https://dns.hetzner.com/api/v1"
+api_key=${HETZNER_KEY:-''}
+zone_id=${HETZNER_ZONE_ID:-''}
+zone_name=${HETZNER_ZONE_NAME:-''}
+
+# Verify that required parameters are set
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$HETZNER_KEY" ]]; then
+  echo "HETZNER_KEY variable not set"
+  exit 1
+fi
+if [ -z "$HETZNER_ZONE_ID" ] && [ -z "$HETZNER_ZONE_NAME" ] ; then
+  echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
+  exit 1
+fi
+
+# Get Zone ID if not set
+if [ -z "$HETZNER_ZONE_ID" ] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+fi
+
+# domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF FS}')
+# domain=${fulldomain%.$domain_root}
+txtname="_acme-challenge.$fulldomain."
+
+echo $zone_id
+# Create TXT record
+response=$(curl --silent -X POST "$api_url/records" \
+     -H 'Content-Type: application/json' \
+     -H "Auth-API-Token: $api_key" \
+     -d '{"value": "'$token'","ttl": 60,"type": "TXT","name": "_acme-challenge.'$fulldomain'.","zone_id": "'$zone_id'"}')
+echo "$response"
+# errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
+# if [[ $errors != "\"ERRORARRAY\":[]" ]]; then
+#     echo "Something went wrong: $errors"
+#     exit 1
+# fi

--- a/dns_scripts/dns_del_hetzner
+++ b/dns_scripts/dns_del_hetzner
@@ -28,6 +28,10 @@ fi
 # Get Zone ID if not set
 if [ -z "$HETZNER_ZONE_ID" ] ; then
   zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+  if [  "$zone_id" == "null" ] ; then
+    echo "Zone by name not found"
+    exit 1
+  fi
 fi
 
 # domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF FS}')
@@ -37,11 +41,17 @@ txtname="_acme-challenge.$fulldomain."
 
 record_id=$(curl --silent -X GET "$api_url/records?zone_id=$zone_id" -H "Auth-API-Token: $api_key" | jq -r '.records[] | select(.name=="'$txtname'") | .id')
 
-# Create TXT record
-response=$(curl --silent -X DELETE "$api_url/records/$record_id" -H "Auth-API-Token: $api_key")
-
-# errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
-if [[ $response != "\"ERRORARRAY\":[]" ]]; then
-    echo "Something went wrong: $errors"
-    exit 1
+if [  "$record_id" == "null" ] ; then
+  echo "Record not found"
+  exit 1
 fi
+
+# Create TXT record
+response=$(curl --silent -X DELETE "$api_url/records/$record_id" -H "Auth-API-Token: $api_key" -o /dev/null -w '%{http_code}')
+
+if [  "$response" != "200" ] ; then
+  echo "Record not deleted"
+  echo "Response code: $response"
+  exit 1
+fi
+

--- a/dns_scripts/dns_del_hetzner
+++ b/dns_scripts/dns_del_hetzner
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="https://dns.hetzner.com/api/v1"
+api_key=${HETZNER_KEY:-''}
+zone_id=${HETZNER_ZONE_ID:-''}
+zone_name=${HETZNER_ZONE_NAME:-''}
+
+# Verify that required parameters are set
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$HETZNER_KEY" ]]; then
+  echo "HETZNER_KEY variable not set"
+  exit 1
+fi
+if [ -z "$HETZNER_ZONE_ID" ] && [ -z "$HETZNER_ZONE_NAME" ] ; then
+  echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
+  exit 1
+fi
+
+# Get Zone ID if not set
+if [ -z "$HETZNER_ZONE_ID" ] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+fi
+
+# domain_root=$(echo "$fulldomain" | awk -F\. '{print $(NF-1) FS $NF FS}')
+# domain=${fulldomain%.$domain_root}
+txtname="_acme-challenge.$fulldomain."
+
+
+record_id=$(curl --silent -X GET "$api_url/records?zone_id=$zone_id" -H "Auth-API-Token: $api_key" | jq -r '.records[] | select(.name=="'$txtname'") | .id')
+
+# Create TXT record
+response=$(curl --silent -X DELETE "$api_url/records/$record_id" -H "Auth-API-Token: $api_key")
+
+# errors=$(echo "$response" | egrep -o "\"ERRORARRAY\":\[.*\]")
+if [[ $response != "\"ERRORARRAY\":[]" ]]; then
+    echo "Something went wrong: $errors"
+    exit 1
+fi

--- a/dns_scripts/dns_del_hetzner
+++ b/dns_scripts/dns_del_hetzner
@@ -20,15 +20,15 @@ if [[ -z "$HETZNER_KEY" ]]; then
   echo "HETZNER_KEY variable not set"
   exit 1
 fi
-if [ -z "$HETZNER_ZONE_ID" ] && [ -z "$HETZNER_ZONE_NAME" ] ; then
+if [[ -z "$HETZNER_ZONE_ID" && -z "$HETZNER_ZONE_NAME" ]] ; then
   echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
   exit 1
 fi
 
 # Get Zone ID if not set
-if [ -z "$HETZNER_ZONE_ID" ] ; then
-  zone_id=$(curl --silent -X GET "$api_url/zones?name=$HETZNER_ZONE_NAME" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
-  if [  "$zone_id" == "null" ] ; then
+if [[ -z "$HETZNER_ZONE_ID" ]] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$zone_name" -H 'Auth-API-Token: '"$api_key"'' | jq -r '.zones[0].id')
+  if [[  "$zone_id" == "null" ]] ; then
     echo "Zone by name not found"
     exit 1
   fi
@@ -39,9 +39,9 @@ fi
 txtname="_acme-challenge.$fulldomain."
 
 
-record_id=$(curl --silent -X GET "$api_url/records?zone_id=$zone_id" -H "Auth-API-Token: $api_key" | jq -r '.records[] | select(.name=="'$txtname'") | .id')
+record_id=$(curl --silent -X GET "$api_url/records?zone_id=$zone_id" -H "Auth-API-Token: $api_key" | jq -r '.records[] | select(.name=="'"$txtname"'") | .id')
 
-if [  "$record_id" == "null" ] ; then
+if [[ "$record_id" == "null" ]] ; then
   echo "Record not found"
   exit 1
 fi
@@ -49,7 +49,7 @@ fi
 # Create TXT record
 response=$(curl --silent -X DELETE "$api_url/records/$record_id" -H "Auth-API-Token: $api_key" -o /dev/null -w '%{http_code}')
 
-if [  "$response" != "200" ] ; then
+if [[ "$response" != "200" ]] ; then
   echo "Record not deleted"
   echo "Response code: $response"
   exit 1


### PR DESCRIPTION
Adds DNS challenge scripts for Hetzner DNS API.

For use the environment variable HETZNER_KEY must be set with an access token.

Also either HETZNER_ZONE_ID or HETZNER_ZONE_NAME must be set as well. When HETZNER_ZONE_ID is set it is directly used. When HETZNER_ZONE_NAME is set the zone id is obtained first.