### PR TITLE
Test for "true" in wildcard property of authorization responses

### DIFF
--- a/.github/workflows/release-and-package.yml
+++ b/.github/workflows/release-and-package.yml
@@ -43,7 +43,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/rpmbuild/RPMS/SRPMS
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
 

--- a/.github/workflows/run-tests-pebble.yml
+++ b/.github/workflows/run-tests-pebble.yml
@@ -17,7 +17,7 @@ jobs:
   test-alpine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Alpine
@@ -25,7 +25,7 @@ jobs:
   test-bash-4-0:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 4.0
@@ -33,7 +33,7 @@ jobs:
   test-bash-4-2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 4.2
@@ -41,7 +41,7 @@ jobs:
   test-bash-5-0:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 5
@@ -49,7 +49,7 @@ jobs:
   test-centos6:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on CentOS6
@@ -57,7 +57,7 @@ jobs:
   test-centos7:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on CentOS7
@@ -65,7 +65,7 @@ jobs:
   test-centos8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on CentOS8
@@ -73,7 +73,7 @@ jobs:
   test-debian:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Debian
@@ -81,7 +81,7 @@ jobs:
   test-rockylinux8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on RockyLinux8
@@ -89,7 +89,7 @@ jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu
@@ -97,7 +97,7 @@ jobs:
   test-ubuntu14:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu14
@@ -105,7 +105,7 @@ jobs:
   test-ubuntu16:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu16
@@ -113,7 +113,7 @@ jobs:
   test-ubuntu18:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu18

--- a/.github/workflows/run-tests-pebble.yml
+++ b/.github/workflows/run-tests-pebble.yml
@@ -18,103 +18,103 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Alpine
         run: test/run-test.sh alpine
   test-bash-4-0:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 4.0
         run: test/run-test.sh bash4-0
   test-bash-4-2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 4.2
         run: test/run-test.sh bash4-2
   test-bash-5-0:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Alpine using Bash 5
         run: test/run-test.sh bash5-0
   test-centos6:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on CentOS6
         run: test/run-test.sh centos6
   test-centos7:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on CentOS7
         run: test/run-test.sh centos7
   test-centos8:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on CentOS8
         run: test/run-test.sh centos8
   test-debian:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Debian
         run: test/run-test.sh debian
   test-rockylinux8:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on RockyLinux8
         run: test/run-test.sh rockylinux8
   test-ubuntu:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu
         run: test/run-test.sh ubuntu
   test-ubuntu14:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu14
         run: test/run-test.sh ubuntu14
   test-ubuntu16:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu16
         run: test/run-test.sh ubuntu16
   test-ubuntu18:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu18
         run: test/run-test.sh ubuntu18

--- a/.github/workflows/run-tests-staging-acmedns.yml
+++ b/.github/workflows/run-tests-staging-acmedns.yml
@@ -20,7 +20,7 @@ jobs:
   test-ubuntu-acmedns:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using acmedns

--- a/.github/workflows/run-tests-staging-acmedns.yml
+++ b/.github/workflows/run-tests-staging-acmedns.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using acmedns
         run: test/run-test.sh ubuntu-acmedns

--- a/.github/workflows/run-tests-staging-duckdns.yml
+++ b/.github/workflows/run-tests-staging-duckdns.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on CentOS7 against Staging using DuckDNS
         run: test/run-test.sh centos7-duckdns
   test-ubuntu-duckdns:
@@ -20,7 +20,7 @@ jobs:
     needs: test-centos7-duckdns
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using DuckDNS
         run: test/run-test.sh ubuntu-duckdns

--- a/.github/workflows/run-tests-staging-duckdns.yml
+++ b/.github/workflows/run-tests-staging-duckdns.yml
@@ -1,15 +1,13 @@
 name: Run tests against Staging server using DuckDNS
 on:
   workflow_dispatch:
-    branches:
-      - master
 env:
   DUCKDNS_TOKEN: ${{ secrets.DUCKDNS_TOKEN == '' && '1d616aa9-b8e4-4bb4-b312-3289de82badb' || secrets.DUCKDNS_TOKEN }}
 jobs:
   test-centos7-duckdns:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on CentOS7 against Staging using DuckDNS
@@ -19,7 +17,7 @@ jobs:
     if: always()
     needs: test-centos7-duckdns
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using DuckDNS

--- a/.github/workflows/run-tests-staging-dynu.yml
+++ b/.github/workflows/run-tests-staging-dynu.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on CentOS7 against Staging using Dynu
         run: test/run-test.sh centos7-dynu
   test-ubuntu-dynu:
@@ -20,7 +20,7 @@ jobs:
     needs: test-centos7-dynu
     steps:
       - uses: actions/checkout@v3
-      - name: Build the docker-compose stack
-        run: docker-compose up -d --build
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using Dynu
         run: test/run-test.sh ubuntu-dynu

--- a/.github/workflows/run-tests-staging-dynu.yml
+++ b/.github/workflows/run-tests-staging-dynu.yml
@@ -1,15 +1,13 @@
 name: Run tests against Staging server using Dynu
 on:
-  workflow_dispatch:
-    branches:
-      - master
+  workflow_dispatch
 env:
   DYNU_API_KEY: ${{ secrets.DYNU_API_KEY == '' && '65cXefd35XbYf36546eg5dYcZT6X52Y2' || secrets.DYNU_API_KEY }}
 jobs:
   test-centos7-dynu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on CentOS7 against Staging using Dynu
@@ -19,7 +17,7 @@ jobs:
     if: always()
     needs: test-centos7-dynu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the docker compose stack
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu against Staging using Dynu

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint check
         uses: azohra/shell-linter@latest
         with:

--- a/README
+++ b/README
@@ -1,76 +1,70 @@
 
-
-GETSSL 
-
+# GETSSL
 
 [Run all tests] [shellcheck]
 
 Obtain SSL certificates from the letsencrypt.org ACME server. Suitable
 for automating the process on remote servers.
 
+Table of Contents
 
-Table of Contents 
-
--   Upgrade broken in v2.43
--   Features
--   Overview
--   Quick Start Guide
--   Manual Installation
--   Getting started
--   Detailed guide to getting started with more examples
--   Wildcard certificates
--   ISPConfig
--   Automating updates
--   Structure
--   Server-Types
--   Revoke a certificate
--   Elliptic curve keys
--   Preferred Chain
--   Include Root certificate in full chain
--   Windows Server and IIS Support
--   Building getssl as an RPM Package (Redhat/CentOS/SuSe/Oracle/AWS)
--   Building getssl as a Debian Package (Debian/Ubuntu)
--   Issues / problems / help
-
+- Upgrade broken in v2.43
+- Features
+- Overview
+- Quick Start Guide
+- Manual Installation
+- Getting started
+- Detailed guide to getting started with more examples
+- Wildcard certificates
+- ISPConfig
+- Automating updates
+- Structure
+- Server-Types
+- Revoke a certificate
+- Elliptic curve keys
+- Preferred Chain
+- Include Root certificate in full chain
+- Windows Server and IIS Support
+- Building getssl as an RPM Package (Redhat/CentOS/SuSe/Oracle/AWS)
+- Building getssl as a Debian Package (Debian/Ubuntu)
+- Issues / problems / help
 
 Upgrade broken in v2.43
 
 The automatic upgrade in v2.43 is broken as the url is incorrect. If you
 have this version installed you’ll need to manually upgrade using:
-curl --silent --user-agent getssl/manual https://raw.githubusercontent.com/srvrco/getssl/latest/getssl --output getssl
-
+curl --silent --user-agent getssl/manual <https://raw.githubusercontent.com/srvrco/getssl/latest/getssl> --output getssl
 
 Features
 
--   BASH - It runs on virtually all unix machines, including BSD, most
+- BASH - It runs on virtually all unix machines, including BSD, most
     Linux distributions, macOS.
--   GET CERTIFICATES FOR REMOTE SERVERS - The tokens used to provide
+- GET CERTIFICATES FOR REMOTE SERVERS - The tokens used to provide
     validation of domain ownership, and the certificates themselves can
     be automatically copied to remote servers (via ssh, sftp or ftp for
     tokens). The script doesn’t need to run on the server itself. This
     can be useful if you don’t have access to run such scripts on the
     server itself, e.g. if it’s a shared server.
--   RUNS AS A DAILY CRON - so certificates will be automatically renewed
+- RUNS AS A DAILY CRON - so certificates will be automatically renewed
     when required.
--   AUTOMATIC CERTIFICATE RENEWALS
--   CHECKS CERTIFICATES ARE CORRECTLY LOADED - After installation of a
+- AUTOMATIC CERTIFICATE RENEWALS
+- CHECKS CERTIFICATES ARE CORRECTLY LOADED - After installation of a
     new certificate it will test the port specified ( see Server-Types
     for options ) that the certificate is actually being used correctly.
--   AUTOMATICALLY UPDATES - The script can automatically update itself
+- AUTOMATICALLY UPDATES - The script can automatically update itself
     with bug fixes etc if required.
--   EXTENSIVELY CONFIGURABLE - With a simple configuration file for each
+- EXTENSIVELY CONFIGURABLE - With a simple configuration file for each
     certificate it is possible to configure it exactly for your needs,
     whether a simple single domain or multiple domains across multiple
     servers on the same certificate.
--   SUPPORTS HTTP AND DNS CHALLENGES - Full ACME implementation
--   SIMPLE AND EASY TO USE
--   DETAILED DEBUG INFO - Whilst it shouldn’t be needed, detailed debug
+- SUPPORTS HTTP AND DNS CHALLENGES - Full ACME implementation
+- SIMPLE AND EASY TO USE
+- DETAILED DEBUG INFO - Whilst it shouldn’t be needed, detailed debug
     information is available.
--   RELOAD SERVICES - After a new certificate is obtained then the
+- RELOAD SERVICES - After a new certificate is obtained then the
     relevant services (e.g. apache/nginx/postfix) can be reloaded.
--   ACME V1 AND V2 - Supports both ACME versions 1 and 2 (note ACMEv1 is
+- ACME V1 AND V2 - Supports both ACME versions 1 and 2 (note ACMEv1 is
     deprecated and clients will automatically use v2)
-
 
 Overview
 
@@ -163,7 +157,7 @@ INSTALLING SOURCE PACKAGES
 To install the source package with the rpm package manager for RedHat,
 CentOS, SuSe, Oracle Linux, or AWS Linux distributions:
 
-    rpm -i getssl-2.47-1.src.rpm 
+    rpm -i getssl-2.47-1.src.rpm
 
 _(Note: rpm installs the source code files in /root/rpmbuild/ as top
 directory for RedHat, CentOS, Oracle Linux, and AWS Linux platforms.
@@ -183,12 +177,12 @@ SPECS and SOURCES directory tree structure. Subsequently, an SDEB can
 also be extracted and installed with the TAR -XVF COMMAND or the files
 listed with the TAR -TVF COMMAND:
 
-    [root@localhost getssl]$ tar -tvf /root/debbuild/SDEBS/getssl-2.47-1.sdeb 
+    [root@localhost getssl]$ tar -tvf /root/debbuild/SDEBS/getssl-2.47-1.sdeb
     -rw-r--r-- root/root   1772110 2022-10-12 20:42 SOURCES/getssl-2.47.tar.gz
     -rw-r--r-- root/root       192 2022-08-02 15:02 SOURCES/getssl.crontab
     -rw-r--r-- root/root       126 2022-08-02 15:02 SOURCES/getssl.logrotate
     -rw-r--r-- root/root      1537 2022-08-02 15:02 SPECS/getssl.spec
-    [root@localhost getssl]$ 
+    [root@localhost getssl]$
 
 For building or rebuilding RPMS or DEB Packages after you have installed
 the associated source packages on your platform, refer to the following:
@@ -473,21 +467,21 @@ certificate is installed correctly
 
   Server-Type        Port   Extra
   ------------------ ------ --------------
-  https              443    
+  https              443
   ftp                21     FTP Explicit
   ftpi               990    FTP Implicit
   imap               143    StartTLS
-  imaps              993    
+  imaps              993
   pop3               110    StartTLS
-  pop3s              995    
+  pop3s              995
   smtp               25     StartTLS
-  smtps_deprecated   465    
+  smtps_deprecated   465
   smtps              587    StartTLS
   smtp_submission    587    StartTLS
   xmpp               5222   StartTLS
-  xmpps              5269   
-  ldaps              636    
-  port number               
+  xmpps              5269
+  ldaps              636
+  port number
 
 
 Revoke a certificate

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For example, the release v2.49 contains the following packages in the release se
 
 ### **Debian Based Packages (Debian, Ubuntu)**
 
-- [getssl_2.49-1_all.deb](https://github.com/srvrco/getssl/releases/download/2.49/getssl_2.49-1_all.deb) (binary)
+- [getssl_2.49-1_all.deb](https://github.com/srvrco/getssl/releases/download/v2.49/getssl_2.49-1_all.deb) (binary)
 
 ### **Installing Binary Packages**
 

--- a/README.md
+++ b/README.md
@@ -111,23 +111,22 @@ Source RPM packages (SRPMS) and Debbuild SDEB packages for source code installat
 RPM and DEB packages for each release include a binary architecture specific package
 and a source package which can be downloaded and built/rebuilt and which contains the source code.
 
-For example, the release v2.47 contains the following packages in the release section:
+For example, the release v2.49 contains the following packages in the release section:
 
 ### **RPM Based Packages (RedHat, CentOS, SuSe, Oracle Linux, AWS Linux)**
 
-- [getssl-2.47-1.src.rpm](https://github.com/jeffmerkey/getssl/releases/download/v2.47/getssl-2.47-1.src.rpm) (source)
-- [getssl-2.47-1.noarch.rpm](https://github.com/jeffmerkey/getssl/releases/download/v2.47/getssl-2.47-1.noarch.rpm) (binary)
+- [getssl-2.49-1.src.rpm](https://github.com/srvrco/getssl/releases/download/2.49/getssl-2.49-1.src.rpm) (source)
+- [getssl-2.49-1.noarch.rpm](https://github.com/srvrco/getssl/releases/download/2.49/getssl-2.49-1.noarch.rpm) (binary)
 
 ### **Debian Based Packages (Debian, Ubuntu)**
 
-- [getssl-2.47-1.sdeb](https://github.com/jeffmerkey/getssl/releases/download/v2.47/getssl-2.47-1.sdeb) (source)
-- [getssl_2.47-1_all.deb](https://github.com/jeffmerkey/getssl/releases/download/v2.47/getssl_2.47-1_all.deb) (binary)
+- [getssl_2.49-1_all.deb](https://github.com/srvrco/getssl/releases/download/2.49/getssl_2.49-1_all.deb) (binary)
 
 ### **Installing Binary Packages**
 
 To install the binary package with the rpm package manager for RedHat, CentOS, SuSe, Oracle Linux, or AWS Linux distributions:
 ```sh
-rpm -i getssl-2.47-1.noarch.rpm
+rpm -i getssl-2.49-1.noarch.rpm
 ```
 
 To deinstall the RPM binary package:
@@ -137,7 +136,7 @@ rpm -e getssl
 
 To install the binary package with the Debian dpkg package manager for Debian and Ubuntu Linux distributions:
 ```sh
-dpkg -i getssl_2.47-1_all.deb
+dpkg -i getssl_2.49-1_all.deb
 ```
 
 To deinstall the Debian dpkg binary package:
@@ -149,21 +148,21 @@ dpkg -r getssl
 
 To install the source package with the rpm package manager for RedHat, CentOS, SuSe, Oracle Linux, or AWS Linux distributions:
 ```sh
-rpm -i getssl-2.47-1.src.rpm 
+rpm -i getssl-2.48-1.src.rpm 
 ```
 *(Note: rpm installs the source code files in /root/rpmbuild/ as top directory for RedHat, CentOS, Oracle Linux, and AWS Linux platforms.  SuSe platforms install the source code files in /usr/src/packages/)*
 
 To install the source package with the Debbuild package tool for Debian or Ubuntu Linux distributions:
 ```sh
-debbuild -i getssl-2.47-1.sdeb
+debbuild -i getssl-2.49-1.sdeb
 ```
 *(Note: Debbuild installs the source code files in /root/debbuild/ as top directory)*
 
 One item of note is that SDEB packages are actually just tar.gz archives renamed with an .sdeb file extension with the files organized into a SPECS and SOURCES directory tree structure.  Subsequently, an SDEB can also be extracted and installed with the **tar -xvf command** or the files listed with the **tar -tvf command**:
 
 ```sh
-[root@localhost getssl]$ tar -tvf /root/debbuild/SDEBS/getssl-2.47-1.sdeb 
--rw-r--r-- root/root   1772110 2022-10-12 20:42 SOURCES/getssl-2.47.tar.gz
+[root@localhost getssl]$ tar -tvf /root/debbuild/SDEBS/getssl-2.49-1.sdeb 
+-rw-r--r-- root/root   1772110 2022-10-12 20:42 SOURCES/getssl-2.49.tar.gz
 -rw-r--r-- root/root       192 2022-08-02 15:02 SOURCES/getssl.crontab
 -rw-r--r-- root/root       126 2022-08-02 15:02 SOURCES/getssl.logrotate
 -rw-r--r-- root/root      1537 2022-08-02 15:02 SPECS/getssl.spec
@@ -680,97 +679,97 @@ Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.BYQw0V
 + umask 022
 + cd /root/rpmbuild/BUILD
 + cd /root/rpmbuild/BUILD
-+ rm -rf getssl-2.47
-+ /usr/bin/gzip -dc /root/rpmbuild/SOURCES/getssl-2.47.tar.gz
++ rm -rf getssl-2.49
++ /usr/bin/gzip -dc /root/rpmbuild/SOURCES/getssl-2.49.tar.gz
 + /usr/bin/tar -xof -
 + STATUS=0
 + '[' 0 -ne 0 ']'
-+ cd getssl-2.47
++ cd getssl-2.49
 + /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 + exit 0
 Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.xpA456
 + umask 022
 + cd /root/rpmbuild/BUILD
-+ cd getssl-2.47
++ cd getssl-2.49
 + exit 0
 Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.zQs24R
 + umask 022
 + cd /root/rpmbuild/BUILD
-+ '[' /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64 '!=' / ']'
-+ rm -rf /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
-++ dirname /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
++ '[' /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64 '!=' / ']'
++ rm -rf /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
+++ dirname /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
 + mkdir -p /root/rpmbuild/BUILDROOT
-+ mkdir /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
-+ cd getssl-2.47
-+ '[' -n /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64 -a /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64 '!=' / ']'
-+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
-+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/bin
-+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts
-+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/other_scripts
-+ /usr/bin/make DESTDIR=/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64 install
-mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
-install -Dvm755 getssl /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/bin/getssl
-'getssl' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/bin/getssl'
-install -dvm755 /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl
-for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/$dir; install -pv $dir/* /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/$dir/; done
-'dns_scripts/Azure-README.txt' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/Azure-README.txt'
-'dns_scripts/Cloudflare-README.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/Cloudflare-README.md'
-'dns_scripts/DNS_IONOS.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
-'dns_scripts/DNS_ROUTE53.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
-'dns_scripts/GoDaddy-README.txt' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
-'dns_scripts/dns_add_acmedns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_acmedns'
-'dns_scripts/dns_add_azure' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_azure'
-'dns_scripts/dns_add_challtestsrv' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
-'dns_scripts/dns_add_clouddns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_clouddns'
-'dns_scripts/dns_add_cloudflare' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_cloudflare'
-'dns_scripts/dns_add_cpanel' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_cpanel'
-'dns_scripts/dns_add_del_aliyun.sh' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_del_aliyun.sh'
-'dns_scripts/dns_add_dnspod' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_dnspod'
-'dns_scripts/dns_add_duckdns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_duckdns'
-'dns_scripts/dns_add_dynu' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_dynu'
-'dns_scripts/dns_add_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_godaddy'
-'dns_scripts/dns_add_hostway' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_hostway'
-'dns_scripts/dns_add_ionos' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ionos'
-'dns_scripts/dns_add_ispconfig' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ispconfig'
-'dns_scripts/dns_add_joker' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_joker'
-'dns_scripts/dns_add_lexicon' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_lexicon'
-'dns_scripts/dns_add_linode' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_linode'
-'dns_scripts/dns_add_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_manual'
-'dns_scripts/dns_add_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
-'dns_scripts/dns_add_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ovh'
-'dns_scripts/dns_add_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
-'dns_scripts/dns_add_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_vultr'
-'dns_scripts/dns_add_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
-'dns_scripts/dns_del_acmedns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_acmedns'
-'dns_scripts/dns_del_azure' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_azure'
-'dns_scripts/dns_del_challtestsrv' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_challtestsrv'
-'dns_scripts/dns_del_clouddns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_clouddns'
-'dns_scripts/dns_del_cloudflare' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_cloudflare'
-'dns_scripts/dns_del_cpanel' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_cpanel'
-'dns_scripts/dns_del_dnspod' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_dnspod'
-'dns_scripts/dns_del_duckdns' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_duckdns'
-'dns_scripts/dns_del_dynu' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_dynu'
-'dns_scripts/dns_del_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_godaddy'
-'dns_scripts/dns_del_hostway' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_hostway'
-'dns_scripts/dns_del_ionos' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ionos'
-'dns_scripts/dns_del_ispconfig' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ispconfig'
-'dns_scripts/dns_del_joker' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_joker'
-'dns_scripts/dns_del_lexicon' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_lexicon'
-'dns_scripts/dns_del_linode' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_linode'
-'dns_scripts/dns_del_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_manual'
-'dns_scripts/dns_del_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
-'dns_scripts/dns_del_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ovh'
-'dns_scripts/dns_del_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
-'dns_scripts/dns_del_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_vultr'
-'dns_scripts/dns_del_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'
-'dns_scripts/dns_freedns.sh' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_freedns.sh'
-'dns_scripts/dns_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_godaddy'
-'dns_scripts/dns_route53.py' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/dns_route53.py'
-'dns_scripts/ispconfig_soap.php' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/dns_scripts/ispconfig_soap.php'
-'other_scripts/cpanel_cert_upload' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/other_scripts/cpanel_cert_upload'
-'other_scripts/iis_install_certeficate.ps1' -> '/root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/usr/share/getssl/other_scripts/iis_install_certeficate.ps1'
-+ install -Dpm 644 /root/rpmbuild/SOURCES/getssl.crontab /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/etc/cron.d/getssl
-+ install -Dpm 644 /root/rpmbuild/SOURCES/getssl.logrotate /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64/etc/logrotate.d/getssl
++ mkdir /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
++ cd getssl-2.49
++ '[' -n /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64 -a /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64 '!=' / ']'
++ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
++ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/bin
++ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts
++ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/other_scripts
++ /usr/bin/make DESTDIR=/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64 install
+mkdir -p /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
+install -Dvm755 getssl /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/bin/getssl
+'getssl' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/bin/getssl'
+install -dvm755 /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl
+for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/$dir; install -pv $dir/* /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/$dir/; done
+'dns_scripts/Azure-README.txt' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/Azure-README.txt'
+'dns_scripts/Cloudflare-README.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/Cloudflare-README.md'
+'dns_scripts/DNS_IONOS.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
+'dns_scripts/DNS_ROUTE53.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
+'dns_scripts/GoDaddy-README.txt' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
+'dns_scripts/dns_add_acmedns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_acmedns'
+'dns_scripts/dns_add_azure' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_azure'
+'dns_scripts/dns_add_challtestsrv' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
+'dns_scripts/dns_add_clouddns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_clouddns'
+'dns_scripts/dns_add_cloudflare' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_cloudflare'
+'dns_scripts/dns_add_cpanel' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_cpanel'
+'dns_scripts/dns_add_del_aliyun.sh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_del_aliyun.sh'
+'dns_scripts/dns_add_dnspod' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_dnspod'
+'dns_scripts/dns_add_duckdns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_duckdns'
+'dns_scripts/dns_add_dynu' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_dynu'
+'dns_scripts/dns_add_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_godaddy'
+'dns_scripts/dns_add_hostway' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_hostway'
+'dns_scripts/dns_add_ionos' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ionos'
+'dns_scripts/dns_add_ispconfig' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ispconfig'
+'dns_scripts/dns_add_joker' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_joker'
+'dns_scripts/dns_add_lexicon' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_lexicon'
+'dns_scripts/dns_add_linode' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_linode'
+'dns_scripts/dns_add_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_manual'
+'dns_scripts/dns_add_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
+'dns_scripts/dns_add_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ovh'
+'dns_scripts/dns_add_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
+'dns_scripts/dns_add_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_vultr'
+'dns_scripts/dns_add_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
+'dns_scripts/dns_del_acmedns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_acmedns'
+'dns_scripts/dns_del_azure' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_azure'
+'dns_scripts/dns_del_challtestsrv' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_challtestsrv'
+'dns_scripts/dns_del_clouddns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_clouddns'
+'dns_scripts/dns_del_cloudflare' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_cloudflare'
+'dns_scripts/dns_del_cpanel' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_cpanel'
+'dns_scripts/dns_del_dnspod' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_dnspod'
+'dns_scripts/dns_del_duckdns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_duckdns'
+'dns_scripts/dns_del_dynu' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_dynu'
+'dns_scripts/dns_del_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_godaddy'
+'dns_scripts/dns_del_hostway' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_hostway'
+'dns_scripts/dns_del_ionos' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ionos'
+'dns_scripts/dns_del_ispconfig' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ispconfig'
+'dns_scripts/dns_del_joker' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_joker'
+'dns_scripts/dns_del_lexicon' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_lexicon'
+'dns_scripts/dns_del_linode' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_linode'
+'dns_scripts/dns_del_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_manual'
+'dns_scripts/dns_del_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
+'dns_scripts/dns_del_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ovh'
+'dns_scripts/dns_del_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
+'dns_scripts/dns_del_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_vultr'
+'dns_scripts/dns_del_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'
+'dns_scripts/dns_freedns.sh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_freedns.sh'
+'dns_scripts/dns_godaddy' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_godaddy'
+'dns_scripts/dns_route53.py' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_route53.py'
+'dns_scripts/ispconfig_soap.php' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/ispconfig_soap.php'
+'other_scripts/cpanel_cert_upload' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/other_scripts/cpanel_cert_upload'
+'other_scripts/iis_install_certeficate.ps1' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/other_scripts/iis_install_certeficate.ps1'
++ install -Dpm 644 /root/rpmbuild/SOURCES/getssl.crontab /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/etc/cron.d/getssl
++ install -Dpm 644 /root/rpmbuild/SOURCES/getssl.logrotate /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/etc/logrotate.d/getssl
 + /usr/lib/rpm/check-buildroot
 + /usr/lib/rpm/redhat/brp-ldconfig
 /sbin/ldconfig: Warning: ignoring configuration file that cannot be opened: /etc/ld.so.conf: No such file or directory
@@ -781,8 +780,8 @@ for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_
 + /usr/lib/rpm/brp-python-bytecompile '' 1
 + /usr/lib/rpm/brp-python-hardlink
 + /usr/bin/true
-Processing files: getssl-2.47-1.noarch
-Provides: getssl = 2.47-1
+Processing files: getssl-2.49-1.noarch
+Provides: getssl = 2.49-1
 Requires(interp): /bin/sh /bin/sh /bin/sh /bin/sh
 Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
 Requires(pre): /bin/sh
@@ -790,14 +789,14 @@ Requires(post): /bin/sh
 Requires(preun): /bin/sh
 Requires(postun): /bin/sh
 Requires: /bin/bash /usr/bin/env
-Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
-Wrote: /root/rpmbuild/SRPMS/getssl-2.47-1.src.rpm
-Wrote: /root/rpmbuild/RPMS/noarch/getssl-2.47-1.noarch.rpm
+Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
+Wrote: /root/rpmbuild/SRPMS/getssl-2.49-1.src.rpm
+Wrote: /root/rpmbuild/RPMS/noarch/getssl-2.49-1.noarch.rpm
 Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.hgma8Q
 + umask 022
 + cd /root/rpmbuild/BUILD
-+ cd getssl-2.47
-+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/getssl-2.47-1.x86_64
++ cd getssl-2.49
++ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64
 + exit 0
 ```
 
@@ -832,111 +831,111 @@ Lua: No Lua module loaded
 Executing (%prep): /bin/sh -e /var/tmp/deb-tmp.prep.92007
 + umask 022
 + cd /root/debbuild/BUILD
-+ /bin/rm -rf getssl-2.47
-+ /bin/gzip -dc /root/debbuild/SOURCES/getssl-2.47.tar.gz
++ /bin/rm -rf getssl-2.49
++ /bin/gzip -dc /root/debbuild/SOURCES/getssl-2.49.tar.gz
 + /bin/tar -xf -
 + STATUS=0
 + '[' 0 -ne 0 ']'
-+ cd getssl-2.47
++ cd getssl-2.49
 + /bin/chmod -Rf a+rX,u+w,go-w .
 + exit 0
 Executing (%build): /bin/sh -e /var/tmp/deb-tmp.build.40956
 + umask 022
 + cd /root/debbuild/BUILD
-+ cd getssl-2.47
++ cd getssl-2.49
 + exit 0
 Executing (%install): /bin/sh -e /var/tmp/deb-tmp.install.36647
 + umask 022
 + cd /root/debbuild/BUILD
-+ cd getssl-2.47
-+ '[' -n /root/debbuild/BUILDROOT/getssl-2.47-1.amd64 -a /root/debbuild/BUILDROOT/getssl-2.47-1.amd64 '!=' / ']'
-+ /bin/rm -rf /root/debbuild/BUILDROOT/getssl-2.47-1.amd64
-+ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/bin
-+ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts
-+ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/other_scripts
-+ /usr/bin/make DESTDIR=/root/debbuild/BUILDROOT/getssl-2.47-1.amd64 install
-mkdir -p /root/debbuild/BUILDROOT/getssl-2.47-1.amd64
-install -Dvm755 getssl /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/bin/getssl
-'getssl' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/bin/getssl'
-install -dvm755 /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl
-for dir in *_scripts; do install -dv /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/$dir; install -pv $dir/* /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/$dir/; done
-'dns_scripts/Azure-README.txt' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/Azure-README.txt'
-'dns_scripts/Cloudflare-README.md' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/Cloudflare-README.md'
-'dns_scripts/DNS_IONOS.md' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
-'dns_scripts/DNS_ROUTE53.md' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
-'dns_scripts/GoDaddy-README.txt' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
-'dns_scripts/dns_add_acmedns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_acmedns'
-'dns_scripts/dns_add_azure' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_azure'
-'dns_scripts/dns_add_challtestsrv' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
-'dns_scripts/dns_add_clouddns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_clouddns'
-'dns_scripts/dns_add_cloudflare' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_cloudflare'
-'dns_scripts/dns_add_cpanel' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_cpanel'
-'dns_scripts/dns_add_del_aliyun.sh' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_del_aliyun.sh'
-'dns_scripts/dns_add_dnspod' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_dnspod'
-'dns_scripts/dns_add_duckdns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_duckdns'
-'dns_scripts/dns_add_dynu' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_dynu'
-'dns_scripts/dns_add_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_godaddy'
-'dns_scripts/dns_add_hostway' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_hostway'
-'dns_scripts/dns_add_ionos' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_ionos'
-'dns_scripts/dns_add_ispconfig' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_ispconfig'
-'dns_scripts/dns_add_joker' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_joker'
-'dns_scripts/dns_add_lexicon' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_lexicon'
-'dns_scripts/dns_add_linode' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_linode'
-'dns_scripts/dns_add_manual' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_manual'
-'dns_scripts/dns_add_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
-'dns_scripts/dns_add_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_ovh'
-'dns_scripts/dns_add_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
-'dns_scripts/dns_add_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_vultr'
-'dns_scripts/dns_add_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
-'dns_scripts/dns_del_acmedns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_acmedns'
-'dns_scripts/dns_del_azure' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_azure'
-'dns_scripts/dns_del_challtestsrv' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_challtestsrv'
-'dns_scripts/dns_del_clouddns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_clouddns'
-'dns_scripts/dns_del_cloudflare' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_cloudflare'
-'dns_scripts/dns_del_cpanel' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_cpanel'
-'dns_scripts/dns_del_dnspod' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_dnspod'
-'dns_scripts/dns_del_duckdns' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_duckdns'
-'dns_scripts/dns_del_dynu' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_dynu'
-'dns_scripts/dns_del_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_godaddy'
-'dns_scripts/dns_del_hostway' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_hostway'
-'dns_scripts/dns_del_ionos' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_ionos'
-'dns_scripts/dns_del_ispconfig' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_ispconfig'
-'dns_scripts/dns_del_joker' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_joker'
-'dns_scripts/dns_del_lexicon' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_lexicon'
-'dns_scripts/dns_del_linode' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_linode'
-'dns_scripts/dns_del_manual' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_manual'
-'dns_scripts/dns_del_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
-'dns_scripts/dns_del_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_ovh'
-'dns_scripts/dns_del_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
-'dns_scripts/dns_del_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_vultr'
-'dns_scripts/dns_del_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'
-'dns_scripts/dns_freedns.sh' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_freedns.sh'
-'dns_scripts/dns_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_godaddy'
-'dns_scripts/dns_route53.py' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/dns_route53.py'
-'dns_scripts/ispconfig_soap.php' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/dns_scripts/ispconfig_soap.php'
-'other_scripts/cpanel_cert_upload' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/other_scripts/cpanel_cert_upload'
-'other_scripts/iis_install_certeficate.ps1' -> '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/usr/share/getssl/other_scripts/iis_install_certeficate.ps1'
-+ install -Dpm 644 /root/debbuild/SOURCES/getssl.crontab /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/etc/cron.d/getssl
-+ install -Dpm 644 /root/debbuild/SOURCES/getssl.logrotate /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/etc/logrotate.d/getssl
++ cd getssl-2.49
++ '[' -n /root/debbuild/BUILDROOT/getssl-2.49-1.amd64 -a /root/debbuild/BUILDROOT/getssl-2.49-1.amd64 '!=' / ']'
++ /bin/rm -rf /root/debbuild/BUILDROOT/getssl-2.49-1.amd64
++ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/bin
++ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts
++ /bin/mkdir -p /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/other_scripts
++ /usr/bin/make DESTDIR=/root/debbuild/BUILDROOT/getssl-2.49-1.amd64 install
+mkdir -p /root/debbuild/BUILDROOT/getssl-2.49-1.amd64
+install -Dvm755 getssl /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/bin/getssl
+'getssl' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/bin/getssl'
+install -dvm755 /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl
+for dir in *_scripts; do install -dv /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/$dir; install -pv $dir/* /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/$dir/; done
+'dns_scripts/Azure-README.txt' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/Azure-README.txt'
+'dns_scripts/Cloudflare-README.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/Cloudflare-README.md'
+'dns_scripts/DNS_IONOS.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
+'dns_scripts/DNS_ROUTE53.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
+'dns_scripts/GoDaddy-README.txt' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
+'dns_scripts/dns_add_acmedns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_acmedns'
+'dns_scripts/dns_add_azure' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_azure'
+'dns_scripts/dns_add_challtestsrv' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
+'dns_scripts/dns_add_clouddns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_clouddns'
+'dns_scripts/dns_add_cloudflare' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_cloudflare'
+'dns_scripts/dns_add_cpanel' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_cpanel'
+'dns_scripts/dns_add_del_aliyun.sh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_del_aliyun.sh'
+'dns_scripts/dns_add_dnspod' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_dnspod'
+'dns_scripts/dns_add_duckdns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_duckdns'
+'dns_scripts/dns_add_dynu' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_dynu'
+'dns_scripts/dns_add_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_godaddy'
+'dns_scripts/dns_add_hostway' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_hostway'
+'dns_scripts/dns_add_ionos' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_ionos'
+'dns_scripts/dns_add_ispconfig' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_ispconfig'
+'dns_scripts/dns_add_joker' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_joker'
+'dns_scripts/dns_add_lexicon' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_lexicon'
+'dns_scripts/dns_add_linode' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_linode'
+'dns_scripts/dns_add_manual' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_manual'
+'dns_scripts/dns_add_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
+'dns_scripts/dns_add_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_ovh'
+'dns_scripts/dns_add_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
+'dns_scripts/dns_add_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_vultr'
+'dns_scripts/dns_add_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
+'dns_scripts/dns_del_acmedns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_acmedns'
+'dns_scripts/dns_del_azure' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_azure'
+'dns_scripts/dns_del_challtestsrv' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_challtestsrv'
+'dns_scripts/dns_del_clouddns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_clouddns'
+'dns_scripts/dns_del_cloudflare' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_cloudflare'
+'dns_scripts/dns_del_cpanel' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_cpanel'
+'dns_scripts/dns_del_dnspod' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_dnspod'
+'dns_scripts/dns_del_duckdns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_duckdns'
+'dns_scripts/dns_del_dynu' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_dynu'
+'dns_scripts/dns_del_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_godaddy'
+'dns_scripts/dns_del_hostway' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_hostway'
+'dns_scripts/dns_del_ionos' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_ionos'
+'dns_scripts/dns_del_ispconfig' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_ispconfig'
+'dns_scripts/dns_del_joker' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_joker'
+'dns_scripts/dns_del_lexicon' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_lexicon'
+'dns_scripts/dns_del_linode' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_linode'
+'dns_scripts/dns_del_manual' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_manual'
+'dns_scripts/dns_del_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
+'dns_scripts/dns_del_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_ovh'
+'dns_scripts/dns_del_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
+'dns_scripts/dns_del_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_vultr'
+'dns_scripts/dns_del_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'
+'dns_scripts/dns_freedns.sh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_freedns.sh'
+'dns_scripts/dns_godaddy' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_godaddy'
+'dns_scripts/dns_route53.py' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_route53.py'
+'dns_scripts/ispconfig_soap.php' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/ispconfig_soap.php'
+'other_scripts/cpanel_cert_upload' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/other_scripts/cpanel_cert_upload'
+'other_scripts/iis_install_certeficate.ps1' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/other_scripts/iis_install_certeficate.ps1'
++ install -Dpm 644 /root/debbuild/SOURCES/getssl.crontab /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/etc/cron.d/getssl
++ install -Dpm 644 /root/debbuild/SOURCES/getssl.logrotate /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/etc/logrotate.d/getssl
 + exit 0
 Checking library requirements...
 Executing (package-creation): /bin/sh -e /var/tmp/deb-tmp.pkg.6107 for getssl
 + umask 022
 + cd /root/debbuild/BUILD
-+ /usr/bin/fakeroot -- /usr/bin/dpkg-deb -b /root/debbuild/BUILDROOT/getssl-2.47-1.amd64/main /root/debbuild/DEBS/all/getssl_2.47-1_all.deb
-dpkg-deb: warning: parsing file '/root/debbuild/BUILDROOT/getssl-2.47-1.amd64/main/DEBIAN/control' near line 10 package 'getssl':
++ /usr/bin/fakeroot -- /usr/bin/dpkg-deb -b /root/debbuild/BUILDROOT/getssl-2.49-1.amd64/main /root/debbuild/DEBS/all/getssl_2.49-1_all.deb
+dpkg-deb: warning: parsing file '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/main/DEBIAN/control' near line 10 package 'getssl':
  missing 'Maintainer' field
 dpkg-deb: warning: ignoring 1 warning about the control file(s)
-dpkg-deb: building package 'getssl' in '/root/debbuild/DEBS/all/getssl_2.47-1_all.deb'.
+dpkg-deb: building package 'getssl' in '/root/debbuild/DEBS/all/getssl_2.49-1_all.deb'.
 + exit 0
 Executing (%clean): /bin/sh -e /var/tmp/deb-tmp.clean.52780
 + umask 022
 + cd /root/debbuild/BUILD
-+ '[' /root/debbuild/BUILDROOT/getssl-2.47-1.amd64 '!=' / ']'
-+ /bin/rm -rf /root/debbuild/BUILDROOT/getssl-2.47-1.amd64
++ '[' /root/debbuild/BUILDROOT/getssl-2.49-1.amd64 '!=' / ']'
++ /bin/rm -rf /root/debbuild/BUILDROOT/getssl-2.49-1.amd64
 + exit 0
-Wrote source package getssl-2.47-1.sdeb in /root/debbuild/SDEBS.
-Wrote binary package getssl_2.47-1_all.deb in /root/debbuild/DEBS/all
+Wrote source package getssl-2.49-1.sdeb in /root/debbuild/SDEBS.
+Wrote binary package getssl_2.49-1_all.deb in /root/debbuild/DEBS/all
 ```
 
 ## Issues / problems / help

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,10 +11,11 @@
 7. git push origin release_2_nn
 8. git push --tags
 
-## The github release-and-package action should
+## Manually start the github release-and-package action
 
 1. Build the .deb and .rpm packages
 2. create a draft release containing the packages and the release note
+3. **IMPORTANT** make sure that the release references tag **v**N.NN otherwise getssl -u fails!
 
 ## Can test the .deb file using the following steps
 

--- a/dns_scripts/GoDaddy-README.txt
+++ b/dns_scripts/GoDaddy-README.txt
@@ -1,3 +1,13 @@
+---------------------------------------------------------------------------
+  NOTE: GoDaddy updated their domain API requirements in 2024!
+
+  It's now required to have at least 10-50 domains in your account.
+  Another option is to purchase the "Discount Domain Club" (Premium!)
+  to gain access to the API.
+
+  Source: https://www.reddit.com/r/godaddy/comments/1bl0f5r/
+---------------------------------------------------------------------------
+
 Using GoDaddy DNS for LetsEncrypt domain validation.
 
 Quick guide to setting up getssl for domain validation of
@@ -22,7 +32,7 @@ There are two prerequisites to using getssl with GoDaddy DNS:
 
 With those in hand, the installation procedure is:
 
-1) Put JSON.sh in the getssl DNS scripts directory 
+1) Put JSON.sh in the getssl DNS scripts directory
    Default: /usr/share/getssl/dns_scripts
 
 2) Open your config file (the global file in ~/.getssl/getssl.cfg

--- a/dns_scripts/INWX-README.md
+++ b/dns_scripts/INWX-README.md
@@ -1,0 +1,62 @@
+## Using INWX DNS for LetsEncrypt domain validation
+
+### Install Requirements
+
+The INWX API Python3 script requires two Python packages:
+
+```bash
+pip3 install INWX.Domrobot tldextract
+```
+
+You could install it for the user running getssl, or you could create a python3 venv.
+
+```bash
+# install python3 venv apt packages
+sudo apt install python3 python3-venv
+
+# Create venv
+python3 -m venv venv
+
+# activate venv
+source venv/bin/activate
+
+# install requirements
+pip3 install INWX.Domrobot tldextract
+```
+
+If you are installing the Python packages in venv, you should make sure that you either
+you either enable the venv before running getssl, or you
+add the venv to the ``DNS_ADD_COMMAND'' and ``DNS_DEL_COMMAND'' commands.
+See example below.
+
+### Enabling the scripts
+
+Set the following options in `getssl.cfg` (either global or domain-specific):
+
+```
+VALIDATE_VIA_DNS="true"
+DNS_ADD_COMMAND="/usr/share/getssl/dns_scripts/dns_add_inwx.py"
+DNS_DEL_COMMAND="/usr/share/getssl/dns_scripts/dns_del_inwx.py"
+```
+
+If you are using a python3 venv as described above, this is an example of how to include it:
+
+```
+VALIDATE_VIA_DNS="true"
+DNS_ADD_COMMAND="/path/to/venv/bin/python3 /usr/share/getssl/dns_scripts/dns_add_inwx.py"
+DNS_DEL_COMMAND="/path/to/venv/bin/python3 /usr/share/getssl/dns_scripts/dns_del_inwx.py"
+```
+
+*Obviously the "/path/to/venv" needs to be replaced with the actual path to your venv, e.g. "/home/getssl/venv".*
+
+### Authentication
+
+Your INWX credentials will be used to authenticate to INWX.
+If you are using a second factor, please have a look at the [INWX Domrobot Pthon3 Client](https://github.com/inwx/python-client) as it is currently not implemented in the inwx api script.
+
+Set the following options in the domain-specific `getssl.cfg` or make sure these enviroment variables are present.
+
+```
+export INWX_USERNAME="your_inwx_username"
+export INWX_PASSWORD="..."
+```

--- a/dns_scripts/Route53-README.md
+++ b/dns_scripts/Route53-README.md
@@ -1,0 +1,37 @@
+# Using Route53 BASH scripts for LetsEncrypt domain validation.
+
+## Quick guide to setting up getssl for domain validation of Route53 DNS domains.
+
+There a few prerequisites to using getssl with Route53 DNS:
+
+1. You will need to set up an IAM user with the necessary permissions to modify resource records in the hosted zone.
+
+   - route53:ListHostedZones
+   - route53:ChangeResourceRecordSets
+
+1. You will need the AWS CLI Client installed on your machine.
+
+1. You will need to configure the client for the IAM user that has permission to modify the resource records.
+
+With those in hand, the installation procedure is:
+
+1. Open your config file (the global file in ~/.getssl/getssl.cfg
+   or the per-account file in ~/.getssl/example.net/getssl.cfg)
+
+1. Set the following options:
+
+   - VALIDATE_VIA_DNS="true"
+   - DNS_ADD_COMMAND="/usr/share/getssl/dns_scripts/dns_add_route53"
+   - DNS_DEL_COMMAND="/usr/share/getssl/dns_scripts/dns_del_route53"
+
+   The AWS CLI profile to use (will use _default_ if not specified)
+
+   - export AWS*CLI_PROFILE="\_profile name*"
+
+1. Set any other options that you wish (per the standard
+   directions.) Use the test CA to make sure that
+   everything is setup correctly.
+
+That's it. getssl example.net will now validate with DNS.
+
+There are additional options, which are documented in `dns_route53 -h`

--- a/dns_scripts/dns_add_inwx.py
+++ b/dns_scripts/dns_add_inwx.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Script to Set TXT Record at INWX using the API
+This script requires the pip packages INWX.Domrobot and tldextract
+This script is using enviroment variables to get inwx credentials
+"""
+
+import sys
+import os
+import argparse
+from INWX.Domrobot import ApiClient
+import tldextract
+
+# Create Parser-Objekt
+parser = argparse.ArgumentParser(
+    description='Using the INWX API to change DNS TXT Records for the ACME DNS-01 Challange',
+        epilog= "The environment variables 'INWX_USERNAME' and 'INWX_PASSWORD' are required too")
+
+# Adding Args
+parser.add_argument('fulldomain', type=str, help='The full domain to add TXT Record.')
+parser.add_argument('token', type=str, help='The ACME DNS-01 token.')
+parser.add_argument('--debug', action='store_true', help='Enable debug mode.')
+
+# Parsing Args
+args = parser.parse_args()
+INWX_FULLDOMAIN = args.fulldomain
+ACME_TOKEN = args.token
+DEBUG = args.debug
+
+# Parsing ENV
+INWX_USERNAME = os.getenv('INWX_USERNAME', '')
+INWX_PASSWORD = os.getenv('INWX_PASSWORD', '')
+
+# Splitting Domain
+domain = tldextract.extract(INWX_FULLDOMAIN)
+INWX_SUBDOMAIN = domain.subdomain
+INWX_DOMAIN = f"{domain.domain}.{domain.suffix}"
+
+# Check if either environment variable is empty and handle the error
+if not INWX_USERNAME or not INWX_PASSWORD:
+    print("Error: The following environment variables are required and cannot be empty:")
+    if not INWX_USERNAME:
+        print("  - INWX_USERNAME: Your INWX account username.")
+    if not INWX_PASSWORD:
+        print("  - INWX_PASSWORD: Your INWX account password.")
+    sys.exit(1)
+
+if DEBUG:
+    print(f'FQDN: {INWX_FULLDOMAIN}')
+    print(f'Domain: {INWX_DOMAIN}')
+    print(f'Subdomain: {INWX_SUBDOMAIN}')
+    print(f'Token: {ACME_TOKEN}')
+    print(f'User: {INWX_USERNAME}')
+    print(f'Password: {INWX_PASSWORD}')
+
+# By default the ApiClient uses the test api (OT&E).
+# If you want to use the production/live api we have a
+# constant named API_LIVE_URL in the ApiClient class.
+# Just set api_url=ApiClient.API_LIVE_URL and you're good.
+# api_client = ApiClient(api_url=ApiClient.API_OTE_URL, debug_mode=DEBUG)
+api_client = ApiClient(api_url=ApiClient.API_LIVE_URL, debug_mode=DEBUG)
+
+# If you have 2fa enabled, take a look at the documentation of the ApiClient#login method
+# to get further information about the login, especially the shared_secret parameter.
+login_result = api_client.login(INWX_USERNAME, INWX_PASSWORD)
+
+# login was successful
+if login_result['code'] == 1000:
+
+    # Make an api call and save the result in a variable.
+    # We want to create a new nameserver record, so we call the api method nameserver.createRecord.
+    # See https://www.inwx.de/en/help/apidoc/f/ch02s15.html#nameserver.createRecord for parameters
+    # ApiClient#call_api returns the api response as a dict.
+    if INWX_SUBDOMAIN == '':
+        domain_entry_result = api_client.call_api(api_method='nameserver.createRecord', method_params={'domain': INWX_DOMAIN, 'name': '_acme-challenge', 'type': 'TXT', 'content': ACME_TOKEN})  # pylint: disable=C0301
+    else:
+        domain_entry_result = api_client.call_api(api_method='nameserver.createRecord', method_params={'domain': INWX_DOMAIN, 'name': f'_acme-challenge.{INWX_SUBDOMAIN}', 'type': 'TXT', 'content': ACME_TOKEN})  # pylint: disable=C0301
+
+    # With or without successful check, we perform a logout.
+    api_client.logout()
+
+    # validating return code
+    if domain_entry_result['code'] == 2302:
+        sys.exit(f"{domain_entry_result['msg']}.\nTry nameserver.updateRecord or nameserver.deleteRecord instead")  # pylint: disable=C0301
+    elif domain_entry_result['code'] == 1000:
+        if DEBUG:
+            print(domain_entry_result['msg'])
+        sys.exit()
+    else:
+        sys.exit(domain_entry_result)
+else:
+    sys.exit('Api login error. Code: ' + str(login_result['code']) + '  Message: ' + login_result['msg'])  # pylint: disable=C0301

--- a/dns_scripts/dns_add_route53
+++ b/dns_scripts/dns_add_route53
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Add token to Route53 dns using dns_route53 bash version
+
+fulldomain="$1"
+token="$2"
+
+[ -z "$ROUTE53_SCRIPT" ] && ROUTE53_SCRIPT="/usr/share/getssl/dns_scripts/dns_route53"
+[[ "$ROUTE53_SCRIPT" =~ ^~ ]] && \
+    eval 'ROUTE53_SCRIPT=`readlink -nf ' $ROUTE53_SCRIPT '`'
+
+if [ ! -x "$ROUTE53_SCRIPT" ]; then
+    echo "$ROUTE53_SCRIPT: not found.  Please install, softlink or set ROUTE53_SCRIPT to its full path"
+    echo "See ROUTE53-README.txt for complete instructions."
+    exit 3
+fi
+
+$ROUTE53_SCRIPT -q add "${fulldomain}." "${token}"

--- a/dns_scripts/dns_del_inwx.py
+++ b/dns_scripts/dns_del_inwx.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Script to remove TXT Record at INWX using the API
+This script requires the pip packages INWX.Domrobot and tldextract
+This script is using enviroment variables to get inwx credentials
+"""
+
+import sys
+import os
+import argparse
+from INWX.Domrobot import ApiClient
+import tldextract
+
+# Create Parser-Objekt
+parser = argparse.ArgumentParser(
+    description='Using the INWX API to remove DNS TXT Records for the ACME DNS-01 Challange',
+        epilog= "The environment variables 'INWX_USERNAME' and 'INWX_PASSWORD' are required too")
+
+# Adding Args
+parser.add_argument('fulldomain', type=str, help='The full domain to add TXT Record.')
+parser.add_argument('token', type=str, help='The ACME DNS-01 token.')
+parser.add_argument('--debug', action='store_true', help='Enable debug mode.')
+
+# Parsing Args
+args = parser.parse_args()
+INWX_FULLDOMAIN = args.fulldomain
+ACME_TOKEN = args.token
+DEBUG = args.debug
+
+# Parsing ENV
+INWX_USERNAME = os.getenv('INWX_USERNAME', '')
+INWX_PASSWORD = os.getenv('INWX_PASSWORD', '')
+
+# Splitting Domain
+domain = tldextract.extract(INWX_FULLDOMAIN)
+INWX_SUBDOMAIN = domain.subdomain
+INWX_DOMAIN = f"{domain.domain}.{domain.suffix}"
+
+# Check if either environment variable is empty and handle the error
+if not INWX_USERNAME or not INWX_PASSWORD:
+    print("Error: The following environment variables are required and cannot be empty:")
+    if not INWX_USERNAME:
+        print("  - INWX_USERNAME: Your INWX account username.")
+    if not INWX_PASSWORD:
+        print("  - INWX_PASSWORD: Your INWX account password.")
+    sys.exit(1)
+
+if DEBUG:
+    print(f'FQDN: {INWX_FULLDOMAIN}')
+    print(f'Domain: {INWX_DOMAIN}')
+    print(f'Subdomain: {INWX_SUBDOMAIN}')
+    print(f'Token: {ACME_TOKEN}')
+    print(f'User: {INWX_USERNAME}')
+    print(f'Password: {INWX_PASSWORD}')
+
+# By default the ApiClient uses the test api (OT&E).
+# If you want to use the production/live api we have a
+# constant named API_LIVE_URL in the ApiClient class.
+# Just set api_url=ApiClient.API_LIVE_URL and you're good.
+# api_client = ApiClient(api_url=ApiClient.API_OTE_URL, debug_mode=DEBUG)
+api_client = ApiClient(api_url=ApiClient.API_LIVE_URL, debug_mode=DEBUG)
+
+# If you have 2fa enabled, take a look at the documentation of the ApiClient#login method
+# to get further information about the login, especially the shared_secret parameter.
+login_result = api_client.login(INWX_USERNAME, INWX_PASSWORD)
+
+# login was successful
+if login_result['code'] == 1000:
+
+    # Make an api call and save the result in a variable.
+    # We want to get a the id of the _acme-challange TXT record,
+    # so we call the api method nameserver.info.
+    # See https://www.inwx.de/en/help/apidoc/f/ch02s15.html#nameserver.info for parameters
+    # ApiClient#call_api returns the api response as a dict.
+    if INWX_SUBDOMAIN == '':
+        domain_info_result = api_client.call_api(api_method='nameserver.info', method_params={'domain': INWX_DOMAIN, 'name': '_acme-challenge', 'type': 'TXT', 'content': ACME_TOKEN})  # pylint: disable=C0301
+    else:
+        domain_info_result = api_client.call_api(api_method='nameserver.info', method_params={'domain': INWX_DOMAIN, 'name': f'_acme-challenge.{INWX_SUBDOMAIN}', 'type': 'TXT', 'content': ACME_TOKEN})  # pylint: disable=C0301
+    if 'record' not in domain_info_result['resData']:
+        api_client.logout()
+        sys.exit(f'No DNS TXT Entry found for _acme-challenge.{INWX_FULLDOMAIN}.')
+    else:
+        for row in domain_info_result['resData']['record']:
+            domain_delete_result = api_client.call_api(api_method='nameserver.deleteRecord', method_params={'id': row['id']})  # pylint: disable=C0301
+            if domain_delete_result['code'] == 1000:
+                if DEBUG:
+                    print(domain_delete_result['msg'])
+            else:
+                api_client.logout()
+                sys.exit(domain_delete_result)
+
+    # With or without successful check, we perform a logout.
+    api_client.logout()
+
+    # validating return code
+    if domain_info_result['code'] == 2302:
+        sys.exit(f"{domain_info_result['msg']}.\nTry nameserver.updateRecord or nameserver.deleteRecord instead")  # pylint: disable=C0301
+    elif domain_info_result['code'] == 1000:
+        if DEBUG:
+            print(domain_info_result['msg'])
+        sys.exit()
+    else:
+        sys.exit(domain_info_result)
+else:
+    sys.exit('Api login error. Code: ' + str(login_result['code']) + '  Message: ' + login_result['msg'])  # pylint: disable=C0301

--- a/dns_scripts/dns_del_route53
+++ b/dns_scripts/dns_del_route53
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Delete token from Route53 dns using dns_route53 bash version
+
+fulldomain="$1"
+token="$2"
+
+[ -z "$ROUTE53_SCRIPT" ] && ROUTE53_SCRIPT="/usr/share/getssl/dns_scripts/dns_route53"
+[[ "$ROUTE53_SCRIPT" =~ ^~ ]] && \
+    eval 'ROUTE53_SCRIPT=`readlink -nf ' $ROUTE53_SCRIPT '`'
+
+if [ ! -x "$ROUTE53_SCRIPT" ]; then
+    echo "$ROUTE53_SCRIPT: not found.  Please install, softlink or set ROUTE53_SCRIPT to its full path"
+    echo "See ROUTE53-README.txt for complete instructions."
+    exit 3
+fi
+
+$ROUTE53_SCRIPT -q del "${fulldomain}." "${token}"

--- a/dns_scripts/dns_route53
+++ b/dns_scripts/dns_route53
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+VERSION="1.0"
+PROG="$(basename "$0")"
+
+QUIET=n
+
+while getopts 'dhp:t:z:i:qv' opt; do
+    case $opt in
+        d) DEBUG="Y"                                   ;;
+        p) AWS_CLI_PROFILE="$OPTARG"                   ;;
+        q) QUIET=                                      ;;
+        v) echo "dns_route53 version $VERSION"; exit 0 ;;
+        z) ROUTE53_HOSTED_ZONE_NAME="$OPTARG"          ;;
+        i) ROUTE53_HOSTED_ZONE_ID="$OPTARG"            ;;
+        *)
+            cat <<EOF
+Usage
+    $PROG [-dt -q] add name data [ttl]
+    $PROG [-dt -h -p "aws-profile-name" -q] del name data
+
+Add or delete TXT records from Route53 Hosted Zone
+
+You must have the AWS CLI installed and a profile configured for this script to work.
+	The IAM user that the profile uses requires the following action permissions in AWS:
+	- route53:ListHostedZones - Not necessary if zone ID is available to this script
+	- route53:ChangeResourceRecordSets
+
+With getssl, this script is called from the dns_add_route53 and
+dns_del_route53 wrapper scripts.
+
+Arguments:
+    add - add the specified record to the domain
+
+    del - remove the specified record from the domain
+
+    name is the fully qualified record name to create the challenge for e.g. www.example.org. Note that trailing '.' is necessary.  Also note that _acme-challenge. will automatically be prepended by this script
+
+    data is the record data, e.g. "myverificationtoken"
+
+    ttl is optional and will default to 120 if not specified
+
+    If it is necessary to turn on debugging externally, define
+    ROUTE53_DEBUG="y" (any non-null string will do).
+    For minimal trace output (to override -q), define ROUTE53_TRACE="y".
+
+Options
+    -d    Provide debugging output - all requests and responses
+    -h    This help.
+    -i:   The hosted zone ID
+    -p:   The AWS CLI profile to use.  Will use default if not specified
+    -q:   Quiet - omit normal success messages
+    -z:   The hosted zone name. Will be used to determine the zone ID if ID was not provided
+
+    All output, except for this help text, is to stderr.
+
+Environment variables
+    ROUTE53_SCRIPT   location of this script
+    ROUTE53_HOSTED_ZONE_NAME The name of the hosted zone name.  If not specified, then the name will be determined from the record name provided to this script
+    ROUTE53_HOSTED_ZONE_ID The id of the hosted zone to be used instead of trying to automatically determine the ID
+    AWS_CLI_PROFILE  the aws cli profile to use if not using default
+
+BUGS
+    Report any issues to https://github.com/xyide/getssl/issues
+EOF
+            exit 0
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "$AWS_CLI_PROFILE" ]; then
+    echo "AWS_CLI_PROFILE not defined.  Using default" >&2
+    AWS_CLI_PROFILE=default
+fi
+
+op="$1"
+if ! [[ "$op" =~ ^(add|del)$ ]]; then
+    echo "Operation must be \"add\" or \"del\"" >&2
+    exit 3
+fi
+name="$2"
+if [ -z "$name" ]; then
+    echo "'name' parameter is required, see -h" >&2
+    exit 3
+fi
+data="$3"
+if [ -z "$data" ]; then
+    echo "'data' parameter is required, see -h" >&2
+    exit 3
+fi
+
+if [ "$op" = 'del' ]; then
+    ttl=120
+elif [ -z "$5" ]; then
+    ttl="120"
+elif ! [[ "$5" =~ ^[0-9]+$ ]]; then
+    echo "TTL $5 is not numeric" >&2
+    exit 3
+elif [ "$5" -lt 120 ]; then
+    [ -n "$VERB" ] && \
+        echo "$5 is too small.  Using TTL of 120 instead" >&2
+    ttl="120"
+else
+    ttl="$5"
+fi
+
+# end processing parameters
+
+[ -n "$DEBUG" ] && \
+    echo "$PROG: $op $name \"$data\" $ttl" >&2
+
+# Determine what actual hosted zone to use.
+
+HOSTED_ZONE_NAME=$ROUTE53_HOSTED_ZONE_NAME
+HOSTED_ZONE_ID=$ROUTE53_HOSTED_ZONE_ID
+RR_NAME="_acme-challenge.${name}"
+RR_VALUE="${data}"
+
+# Function to parse through the segments in the supplied name
+# to determine the zone and its id
+function determine_hosted_zone_name_and_id() {
+    TMP_NAME=$name
+    TMP_RR_NAME=
+	while [[ "$TMP_NAME" =~ ^([^.]+)\.([^.]+.*) ]]; do
+		if [ -n "${TMP_RR_NAME}" ]; then 
+			TMP_RR_NAME="${TMP_RR_NAME}."; 
+		fi
+		TMP_RR_NAME="${TMP_RR_NAME}${BASH_REMATCH[1]}"
+		testdomain="${BASH_REMATCH[2]}"
+		[ -n "$DEBUG" ] && echo "Testing hosted zone ${testdomain}"
+		TMP_NAME=$testdomain
+		if [[ ! "$TMP_NAME" =~ [^.]+\.[^.]+ ]]; then
+			[ -n "$DEBUG" ] && echo "No segments left"
+				exit 1
+		fi
+	
+		TMP_ZONE_ID=$(aws --profile=${AWS_CLI_PROFILE} route53 list-hosted-zones --query "HostedZones[?Name=='${testdomain}'].Id | [0]" | sed -e 's/^"//' -e 's/"$//')
+	
+		
+		if [ "${TMP_ZONE_ID}" != "null" ]; then
+			[ -n "$DEBUG" ] && echo "Found hosted zone ${testdomain}"
+			HOSTED_ZONE_NAME=${testdomain}
+			HOSTED_ZONE_ID=$TMP_ZONE_ID
+			break
+		fi
+	done
+}
+
+# If zone ID is specified, then use it to determine the hosted zone name
+if [ -n "${HOSTED_ZONE_ID}" ]; then
+	HOSTED_ZONE_NAME=$(aws --profile=${AWS_CLI_PROFILE} route53 list-hosted-zones --query "HostedZones[?Id=='${ZONE_ID}'].Name | [0]" | sed -e 's/^"//' -e 's/"$//')
+# If zone name is specified, then use it to get the zone id
+elif [ -n "${HOSTED_ZONE_NAME}" ]; then
+	HOSTED_ZONE_ID=$(aws --profile=${AWS_CLI_PROFILE} route53 list-hosted-zones --query "HostedZones[?Name=='${HOSTED_ZONE_NAME}'].Id | [0]" | sed -e 's/^"//' -e 's/"$//')
+else
+	determine_hosted_zone_name_and_id
+fi
+
+
+	if [ -z "${HOSTED_ZONE_ID}" ]; then
+	echo "Hosted zone id not specified or determined" >&2
+    exit 3
+fi
+
+if [ "$op" = "add" ]; then
+	ACTION="UPSERT"
+elif [ "$op" = "del" ]; then
+	ACTION="DELETE"
+else
+	echo "Unsupported Operation: $op" >&2
+fi
+
+CHANGE_BATCH='
+{
+    "Comment": "GetSSL LetsEncrypt DNS Challenge",
+    "Changes": [{
+      "Action"             : "'"$ACTION"'",
+      "ResourceRecordSet"  : {
+        "Name"             : "'"$RR_NAME"'",
+        "Type"             : "TXT",
+        "TTL"              : '${ttl}',
+        "ResourceRecords"  : [{
+            "Value"         : "\"'$RR_VALUE'\""
+        }]
+      }
+    }]
+  }
+'
+
+
+[ -n "$DEBUG" ] && echo "${CHANGE_BATCH}" >&2
+
+aws \
+	--profile=${AWS_CLI_PROFILE} \
+	route53 \
+	change-resource-record-sets \
+	--hosted-zone-id=${HOSTED_ZONE_ID} \
+	--change-batch "${CHANGE_BATCH}"
+exit $?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: '3'
 services:
   pebble:
-    image: letsencrypt/pebble:latest
+    image: ghcr.io/letsencrypt/pebble:latest
     # TODO enable -strict
-    command: pebble -config /test/config/pebble-config.json -dnsserver 10.30.50.3:53
+    command: -dnsserver 10.30.50.3:53
     environment:
       # with Go 1.13.x which defaults TLS 1.3 to on
       GODEBUG: "tls13=1"
@@ -15,8 +14,8 @@ services:
       acmenet:
         ipv4_address: 10.30.50.2
   challtestsrv:
-    image: letsencrypt/pebble-challtestsrv:latest
-    command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.3 -dns01 ":53"
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
+    command: -defaultIPv6 "" -defaultIPv4 10.30.50.3 -dns01 ":53"
     ports:
       - 8055:8055  # HTTP Management API
     networks:

--- a/getssl
+++ b/getssl
@@ -548,7 +548,7 @@ check_challenge_completion() { # checks with the ACME server if our challenge is
 
     # if ACME response is pending (they haven't completed checks yet)
     # or valid (completed checks but not created certificate) then wait and try again.
-    if [[ "$status" == "pending" ]] || [[ "$status" == "valid" ]]; then
+    if [[ "$status" == "pending" ]] || [[ "$status" == "valid" ]] || [[ "$status" == "processing" ]]; then
       info "Pending"
     else
       err_detail=$(echo "$response" | grep "detail")

--- a/getssl
+++ b/getssl
@@ -539,11 +539,11 @@ check_challenge_completion() { # checks with the ACME server if our challenge is
       break;
     fi
 
-    # if ACME response is that their check gave an invalid response, error exit
+    # if ACME response is "invalid" then abandon the order request - returns error so it can be retried
     if [[ "$status" == "invalid" ]] ; then
       err_detail=$(echo "$response" | grep "detail")
-      # TODO need to check for "DNS problem: SERVFAIL looking up CAA ..." and retry
-      error_exit "$domain:Verify error:$err_detail"
+      info "$domain:Verify error:$err_detail"
+      return 1
     fi
 
     # if ACME response is pending (they haven't completed checks yet)
@@ -557,6 +557,7 @@ check_challenge_completion() { # checks with the ACME server if our challenge is
     debug "sleep 5 secs before testing verify again"
     sleep 5
   done
+  return 0
 }
 
 check_challenge_completion_dns() { # perform validation via DNS challenge
@@ -1469,8 +1470,12 @@ for d in "${alldomains[@]}"; do
 
       # let Let's Encrypt check
       check_challenge_completion "${uri}" "${d}" "${keyauthorization}"
-
+      result=$?
       del_dns_rr "${d}" "${auth_key}"
+      if [[ $result -eq 1 ]]; then
+        # check_challenge_completion failed with "invalid" - order creation cancelled, return error so we can retryS
+        return 1
+      fi
     else      # set up the correct http token for verification
       if [[ $API -eq 1 ]]; then
         # get the token from the http component
@@ -1523,6 +1528,7 @@ for d in "${alldomains[@]}"; do
       fi
 
       check_challenge_completion "$uri" "$d" "$keyauthorization"
+      result=$?
 
       debug "remove token from ${DOMAIN_ACL}"
       IFS=\; read -r -a token_locations <<<"$DOMAIN_ACL"
@@ -1552,12 +1558,17 @@ for d in "${alldomains[@]}"; do
           rm -f "${t_loc:?}/${token:?}"
         fi
       done
+      if [[ $result -eq 1 ]]; then
+        # check_challenge_completion failed with "invalid" - order creation cancelled, return error so we can retryS
+        return 1
+      fi
     fi
     # increment domain-counter
     ((dn++))
   fi
 done # end of ... loop through domains for cert ( from SANS list)
 #end of verify each domain.
+return 0
 }
 
 get_auth_dns() { # get the authoritative dns server for a domain (sets primary_ns )
@@ -1632,7 +1643,7 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
         if [[ "$out" == *SERVFAIL* ]]; then
           debug Output from "$HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS ${gad_d}" contains SERVFAIL
           debug "$out"
-          sleep 2
+          sleep 5
         fi
         ((i++))
       done
@@ -1824,15 +1835,24 @@ get_certificate() { # get certificate for csr, if all domains validated.
   else # APIv2
     info "Requesting Finalize Link"
     send_signed_request "$FinalizeLink" "{\"csr\": \"$der\"}" "needbase64"
-    info Requesting Order Link
-    debug "order link was $OrderLink"
+
+    info Checking Finalize status
+    debug "POST-as-GET order link ($OrderLink) to check status"
     send_signed_request "$OrderLink" ""
-    # if ACME response is processing (still creating certificates) then wait and try again.
-    while [[ "$response_status" == "processing" ]]; do
+
+    # if ACME response is pending (they haven't completed checks yet) or ready (awaiting finalization)
+    # or processing (still creating certificates) then wait and check again.
+    count=0
+    while [[ "$response_status" != "valid" ]]; do
       info "ACME server still Processing certificates"
       sleep 5
       send_signed_request "$OrderLink" ""
+      ((count++))
+      if [[ $count -gt 10 ]]; then
+        error_exit "Finalize failed - checked server 10 times but certificate still not ready"
+      fi
     done
+
     info "Requesting certificate"
     CertData=$(json_get "$response" "certificate")
     send_signed_request "$CertData" "" "" "$gc_fullchain"
@@ -3472,11 +3492,25 @@ else
   read -r -a alldomains <<< "$(echo "$DOMAIN,$SANS" | sed "s/,/ /g")"
 fi
 
-if [[ $API -eq 2 ]]; then
-  create_order
-fi
+# Try again if order creation fails (means check_challenge_completion returned "invalid" - generally DNS failure)
+retry=0
+while [[ $retry -lt 3 ]]
+do
+  if [[ $API -eq 2 ]]; then
+    create_order
+  fi
 
-fulfill_challenges
+  fulfill_challenges
+  result=$?
+  if [[ $result -eq 0 ]]; then
+    break
+  fi
+  ((retry++))
+done
+
+if [[ $retry -ge 3 ]]; then
+  error_exit "$domain: fulfill_challenges failed 3 times"
+fi
 
 # Verification has been completed for all SANS, so request certificate.
 info "Verification completed, obtaining certificate."

--- a/getssl
+++ b/getssl
@@ -290,6 +290,7 @@
 # 2023-02-04 Create newline to ensure [SAN] section can be parsed (#792)(MRigal)
 # 2023-02-22 Remove cronie from deb package dependencies (2.48)
 # 2024-03-18 Refresh the TXT record if a CNAME is found (JoergBruce #828) (2.49)
+# 2024-03-26 Test for "true" in wildcard property of authorization responses
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in

--- a/getssl
+++ b/getssl
@@ -1241,7 +1241,7 @@ create_order() {
       for d in "${alldomains[@]}"; do
         # Convert domain to lowercase as response from server will be in lowercase
         lower_d=$(echo "$d" | tr "[:upper:]" "[:lower:]")
-        if [[ ( "$lower_d" == "$authdomain" && -z "$wildcard" ) || ( "$lower_d" == "*.${authdomain}" && -n "$wildcard" ) ]]; then
+        if [[ ( "$lower_d" == "$authdomain" && "$wildcard" != "true" ) || ( "$lower_d" == "*.${authdomain}" && "$wildcard" == "true" ) ]]; then
           debug "Saving authorization response for $authdomain for domain alldomains[$dn]"
           debug "Response = ${response//[$'\t\r\n']}"
           AuthLinkResponse[dn]=$response

--- a/getssl
+++ b/getssl
@@ -1622,9 +1622,20 @@ get_auth_dns() { # get the authoritative dns server for a domain (sets primary_n
 
     # Query for NS records
     if [[ -z "$res" ]]; then
-      debug Using "$HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS ${gad_d}" to find primary nameserver
-      # shellcheck disable=SC2086
-      res=$($HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS "${gad_d}"| grep -E "IN\W(NS|SOA)\W")
+      out="SERVFAIL"
+      i=0
+      while [[ "$out" == *"SERVFAIL"* ]] && [[ $i -lt 5 ]]; do
+        debug Using "$HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS ${gad_d}" to find primary nameserver
+        # shellcheck disable=SC2086
+        out=$($HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS "${gad_d}")
+        res=$(echo "$out"| grep -E "IN\W(NS|SOA)\W")
+        if [[ "$out" == *SERVFAIL* ]]; then
+          debug Output from "$HAS_DIG_OR_DRILL $DNS_CHECK_OPTIONS ${gad_s} NS ${gad_d}" contains SERVFAIL
+          debug "$out"
+          sleep 2
+        fi
+        ((i++))
+      done
     fi
 
     if [[ -n "$res" ]]; then

--- a/test/24-wildcard-sans.bats
+++ b/test/24-wildcard-sans.bats
@@ -50,7 +50,6 @@ teardown_file() {
     check_output_for_errors
     run openssl x509 -noout -text -in "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt"
     # verify certificate is for wildcard domain with non-wildcard domain in the Subject Alternative Name list
-    # assert_output --regexp "Subject: CN[ ]?=[ ]?\*.wild-${GETSSL_HOST}"
     assert_output --partial "DNS:${GETSSL_HOST}"
 }
 
@@ -69,6 +68,5 @@ teardown_file() {
     check_output_for_errors
     run openssl x509 -noout -text -in "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt"
     # verify certificate is for non-wildcard domain with wildcard domain in the Subject Alternative Name list
-    # assert_output --regexp "Subject: CN[ ]?=[ ]?${GETSSL_HOST}"
     assert_output --partial "DNS:*.wild-${GETSSL_HOST}"
 }

--- a/test/24-wildcard-sans.bats
+++ b/test/24-wildcard-sans.bats
@@ -50,7 +50,7 @@ teardown_file() {
     check_output_for_errors
     run openssl x509 -noout -text -in "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt"
     # verify certificate is for wildcard domain with non-wildcard domain in the Subject Alternative Name list
-    assert_output --regexp "Subject: CN[ ]?=[ ]?\*.wild-${GETSSL_HOST}"
+    # assert_output --regexp "Subject: CN[ ]?=[ ]?\*.wild-${GETSSL_HOST}"
     assert_output --partial "DNS:${GETSSL_HOST}"
 }
 
@@ -69,6 +69,6 @@ teardown_file() {
     check_output_for_errors
     run openssl x509 -noout -text -in "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt"
     # verify certificate is for non-wildcard domain with wildcard domain in the Subject Alternative Name list
-    assert_output --regexp "Subject: CN[ ]?=[ ]?${GETSSL_HOST}"
+    # assert_output --regexp "Subject: CN[ ]?=[ ]?${GETSSL_HOST}"
     assert_output --partial "DNS:*.wild-${GETSSL_HOST}"
 }

--- a/test/34-ftp-passive.bats
+++ b/test/34-ftp-passive.bats
@@ -212,7 +212,16 @@ EOF
     # assert_line --partial "SSL connection using TLSv1.3"
     assert_line --partial "200 PROT now Private"
 
-    check_output_for_errors
+    # 22-May-2024 tweak assert_success on ubuntu16 as ftp output contains the
+    # message "error fetching CN from cert:The requested data were not available."
+    if [[ $GETSSL_OS == ubuntu16 ]]; then
+        refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+        refute_output --regexp '[^_][Ee][Rr][Rr][Oo][Rr][^:badNonce|^ fetching CN from cert]'
+        refute_output --regexp '[^_][Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+        refute_line --partial 'command not found'
+    else
+        check_output_for_errors
+    fi
 }
 
 
@@ -275,5 +284,14 @@ EOF
     create_certificate
     assert_success
     assert_line --partial "200 PROT now Private"
-    check_output_for_errors
+    # 22-May-2024 skip assert_success on ubuntu16 as ftp output contains the
+    # message "error fetching CN from cert:The requested data were not available."
+    if [[ $GETSSL_OS == ubuntu16 ]]; then
+        refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+        refute_output --regexp '[^_][Ee][Rr][Rr][Oo][Rr][^:badNonce|^ fetching CN from cert]'
+        refute_output --regexp '[^_][Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+        refute_line --partial 'command not found'
+    else
+        check_output_for_errors
+    fi
 }

--- a/test/34-ftp-ports.bats
+++ b/test/34-ftp-ports.bats
@@ -98,7 +98,16 @@ EOF
     # assert_line --partial "SSL connection using TLSv1.3"
     assert_line --partial "200 PROT now Private"
 
-    check_output_for_errors
+    # 22-May-2024 skip assert_success on ubuntu16 as ftp output contains the
+    # message "error fetching CN from cert:The requested data were not available."
+    if [[ $GETSSL_OS == ubuntu16 ]]; then
+        refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+        refute_output --regexp '[^_][Ee][Rr][Rr][Oo][Rr][^:badNonce|^ fetching CN from cert]'
+        refute_output --regexp '[^_][Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+        refute_line --partial 'command not found'
+    else
+        check_output_for_errors
+    fi
 }
 
 
@@ -163,5 +172,14 @@ EOF
     create_certificate
     assert_success
     assert_line --partial "200 PROT now Private"
-    check_output_for_errors
+    # 22-May-2024 skip assert_success on ubuntu16 as ftp output contains the
+    # message "error fetching CN from cert:The requested data were not available."
+    if [[ $GETSSL_OS == ubuntu16 ]]; then
+        refute_output --regexp '[Ff][Aa][Ii][Ll][Ee][Dd]'
+        refute_output --regexp '[^_][Ee][Rr][Rr][Oo][Rr][^:badNonce|^ fetching CN from cert]'
+        refute_output --regexp '[^_][Ww][Aa][Rr][Nn][Ii][Nn][Gg]'
+        refute_line --partial 'command not found'
+    else
+        check_output_for_errors
+    fi
 }

--- a/test/35-preferred-chain.bats
+++ b/test/35-preferred-chain.bats
@@ -53,8 +53,8 @@ EOF
 
 @test "Use PREFERRED_CHAIN to select the default root" {
     if [ -n "$STAGING" ]; then
-        PREFERRED_CHAIN="\(STAGING\) Doctored Durian Root CA X3"
-        CHECK_CHAIN="(STAGING) Doctored Durian Root CA X3"
+        PREFERRED_CHAIN="\(STAGING\) Pretend Pear X1"
+        CHECK_CHAIN="(STAGING) Pretend Pear X1"
     else
         PREFERRED_CHAIN=$(curl --silent https://pebble:15000/roots/0 | openssl x509 -text -noout | grep Issuer: | awk -F"CN *= *" '{ print $2 }')
         PREFERRED_CHAIN="${PREFERRED_CHAIN# }" # remove leading whitespace

--- a/test/Dockerfile-centos7
+++ b/test/Dockerfile-centos7
@@ -1,5 +1,10 @@
 FROM centos:centos7
 
+# Centos 7 is EOL and is no longer available from the usual mirrors, so switch to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 # Update and install required software
 RUN yum -y update
 RUN yum -y install epel-release

--- a/test/Dockerfile-centos7
+++ b/test/Dockerfile-centos7
@@ -13,9 +13,9 @@ RUN yum -y install ftp vsftpd
 RUN yum -y install openssh-server
 
 # Set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-centos7-duckdns
+++ b/test/Dockerfile-centos7-duckdns
@@ -8,12 +8,12 @@ RUN yum -y install epel-release
 RUN yum -y install git curl bind-utils ldns wget which nginx jq
 
 # Set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
-ENV staging "true"
-ENV dynamic_dns "dynu"
+ENV staging="true"
+ENV dynamic_dns="dynu"
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-centos7-dynu
+++ b/test/Dockerfile-centos7-dynu
@@ -8,12 +8,12 @@ RUN yum -y install epel-release
 RUN yum -y install git curl bind-utils ldns wget which nginx jq
 
 # Set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
-ENV staging "true"
-ENV dynamic_dns "duckdns"
+ENV staging="true"
+ENV dynamic_dns="duckdns"
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki

--- a/test/Dockerfile-centos8
+++ b/test/Dockerfile-centos8
@@ -15,9 +15,9 @@ RUN yum -y install ftp vsftpd
 RUN yum -y install openssh-server
 
 # Set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-debian
+++ b/test/Dockerfile-debian
@@ -11,9 +11,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-rockylinux8
+++ b/test/Dockerfile-rockylinux8
@@ -10,9 +10,9 @@ RUN yum -y update && \
         glibc-locale-source glibc-langpack-en # for en_US.UTF-8 support
 
 # Set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-ubuntu
+++ b/test/Dockerfile-ubuntu
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # Note this image uses mawk1.3
 
 # Set noninteractive otherwise tzdata hangs
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and install required software
 RUN apt-get update --fix-missing
@@ -15,9 +15,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 # Setup ftp
 ENV VSFTPD_CONF=/etc/vsftpd.conf

--- a/test/Dockerfile-ubuntu-acmedns
+++ b/test/Dockerfile-ubuntu-acmedns
@@ -3,14 +3,14 @@ FROM ubuntu:latest
 # Note this image uses mawk1.3
 
 # Set noninteractive otherwise tzdata hangs
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Ensure tests in this image use the staging server
-ENV staging "true"
+ENV staging="true"
 # 2016ENV dynamic_dns "acme-dns"
-ENV ACMEDNS_API_USER 49ac5f6d-74cd-4aca-acfe-f9457af7894c
-ENV ACMEDNS_API_KEY 2NPGF8cH7PeTrHZWXImi1prhTsQGz2pdCC7Za5zE
-ENV ACMEDNS_SUBDOMAIN 7268181b-7075-4dce-be51-9c20c205cf6e
+ENV ACMEDNS_API_USER=49ac5f6d-74cd-4aca-acfe-f9457af7894c
+ENV ACMEDNS_API_KEY=2NPGF8cH7PeTrHZWXImi1prhTsQGz2pdCC7Za5zE
+ENV ACMEDNS_SUBDOMAIN=7268181b-7075-4dce-be51-9c20c205cf6e
 
 # Update and install required software
 RUN apt-get update --fix-missing
@@ -20,9 +20,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 

--- a/test/Dockerfile-ubuntu-duckdns
+++ b/test/Dockerfile-ubuntu-duckdns
@@ -3,11 +3,11 @@ FROM ubuntu:latest
 # Note this image uses mawk1.3
 
 # Set noninteractive otherwise tzdata hangs
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Ensure tests in this image use the staging server
-ENV staging "true"
-ENV dynamic_dns "duckdns"
+ENV staging="true"
+ENV dynamic_dns="duckdns"
 
 # Update and install required software
 RUN apt-get update --fix-missing
@@ -17,9 +17,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 

--- a/test/Dockerfile-ubuntu-dynu
+++ b/test/Dockerfile-ubuntu-dynu
@@ -3,11 +3,11 @@ FROM ubuntu:latest
 # Note this image uses mawk1.3
 
 # Set noninteractive otherwise tzdata hangs
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Ensure tests in this image use the staging server
-ENV staging "true"
-ENV dynamic_dns "dynu"
+ENV staging="true"
+ENV dynamic_dns="dynu"
 
 # Update and install required software
 RUN apt-get update --fix-missing
@@ -17,9 +17,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 

--- a/test/Dockerfile-ubuntu14
+++ b/test/Dockerfile-ubuntu14
@@ -13,9 +13,9 @@ RUN apt-get update --fix-missing && \
 
 # Set locale
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-ubuntu16
+++ b/test/Dockerfile-ubuntu16
@@ -12,9 +12,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/Dockerfile-ubuntu18
+++ b/test/Dockerfile-ubuntu18
@@ -12,9 +12,9 @@ RUN apt-get install -y locales # for idn testing
 
 # Set locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /root
 RUN mkdir -p /etc/nginx/pki/private

--- a/test/README-Testing.md
+++ b/test/README-Testing.md
@@ -6,7 +6,7 @@ For continuous integration testing we have the following:
 
 `gitactions` script which runs whenever a PR is pushed:
 
-1. Uses `docker-compose` to start `pebble` (letsencrypt test server) and `challtestsrv` (minimal dns client for pebble)
+1. Uses `docker compose` to start `pebble` (letsencrypt test server) and `challtestsrv` (minimal dns client for pebble)
 2. Then runs the `bats` test scripts (all the files with a ".bats" extension) for each OS (alpine, centos6, debian, ubuntu)
 3. Runs the `bats` test script against the staging server (using ubuntu docker image and duckdns.org)
 
@@ -15,33 +15,34 @@ Tests can also be triggered manually from the GitHub website.
 For dynamic DNS tests, you need accounts on duckdns.org and dynu.com, and need to create 4 domain names in each account.
 
 For duckdns.org:
+
 - Add DUCKDNS_TOKEN to your repository's environment secrets.  The value is your account's token
-- Add domains <reponame>-centos7-getssl.duckdns.org, wild-<reponame>-centos7.duckdns.org, <reponame>-ubuntu-getssl.duckdns.org, and wild-<reponame>-ubuntu-getssl.duckdns.org
+- Add domains \<reponame>-centos7-getssl.duckdns.org, wild-\<reponame>-centos7.duckdns.org, \<reponame>-ubuntu-getssl.duckdns.org, and wild-\<reponame>-ubuntu-getssl.duckdns.org
 
 For dynu.com:
- - Add DYNU_API_KEY to your repository's environment secrets.  The value is your account's API Key.
- - Add domains <reponame>-centos7-getssl.freedns.org, wild-<reponame>-centos7.freedns.org, <reponame>-ubuntu-getssl.freedns.org, and wild-<reponame>-ubuntu-getssl.freedns.org
 
-To run dynamic DNS tests outside the CI environment, you need accounts without <reponame> in the domain names.  Export the environment variable corresponding to the secrets (with the same values).
+- Add DYNU_API_KEY to your repository's environment secrets.  The value is your account's API Key.
+- Add domains \<reponame>-centos7-getssl.freedns.org, wild-\<reponame>-centos7.freedns.org, \<reponame>-ubuntu-getssl.freedns.org, and wild-\<reponame>-ubuntu-getssl.freedns.org
 
-For individual accounts, <reponame> is your github account name.
+To run dynamic DNS tests outside the CI environment, you need accounts without \<reponame> in the domain names.  Export the environment variable corresponding to the secrets (with the same values).
 
+For individual accounts, \<reponame> is your github account name.
 
 ## To run all the tests on a single OS
 
-1. Start `pebble` and `challtestsrv` using ```docker-compose up -d --build```
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. Run the test suite ```test/run-test.sh [<os>]```
 3. eg. `test/run-test.sh ubuntu16`
 
 ## To run a single bats test on a single OS
 
-1. Start `pebble` and `challtestsrv` using ```docker-compose up -d --build```
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. ```test/run-test.sh <os> bats <bats test script>```
 3. e.g. `test/run-test.sh ubuntu bats /getssl/test/1-simple-http01.bats`
 
 ## To debug a test
 
-1. Start `pebble` and `challtestsrv` using ```docker-compose up -d --build```
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. ```run-test.sh <os> /getssl/test/debug-test.sh <getssl config file>```
 3. e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01-cfg`
 

--- a/test/README-Testing.md
+++ b/test/README-Testing.md
@@ -44,7 +44,8 @@ For individual accounts, \<reponame> is your github account name.
 
 1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. ```run-test.sh <os> /getssl/test/debug-test.sh <getssl config file>```
-3. e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01-cfg`
+3. e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
+4. or (`test/run-test.sh ubuntu /getssl/test/debug-test.sh -d getssl-http01.cfg`)
 
 ## TODO
 

--- a/test/debug-test.sh
+++ b/test/debug-test.sh
@@ -28,3 +28,4 @@ fi
 cp "${CONFIG_FILE}" "${INSTALL_DIR}/.getssl/${GETSSL_HOST}/getssl.cfg"
 # shellcheck disable=SC2086
 "${CODE_DIR}/getssl" -U ${DEBUG} -f "$GETSSL_HOST" 3>&1
+#bash

--- a/test/run-test.cmd
+++ b/test/run-test.cmd
@@ -1,10 +1,15 @@
-@echo off
+@echo on
 IF %1.==. GOTO NoOS
 SET OS=%1
 
 :CheckCommand
 IF %2.==. GOTO NoCmd
 SET COMMAND=%2 %3
+
+:CheckBats
+IF NOT %3.==. GOTO CheckAlias
+SET COMMAND=bats %2
+IF NOT "%COMMAND:~5,12%"=="/getssl/test" SET COMMAND=bats /getssl/test/%2
 
 :CheckAlias
 REM check if OS *contains* staging

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -3,6 +3,8 @@
 if [ $# -eq 0 ]; then
   echo "Usage: $(basename "$0") <os> [<command>]"
   echo "e.g. $(basename "$0") alpine bats /getssl/test"
+  echo "e.g. $(basename "$0") ubuntu 11-mixed-case.bats"
+  echo "e.g. $(basename "$0") ubuntu /getssl/test/debug-test.sh -d getssl-http01.cfg"
   exit 1
 fi
 OS=$1
@@ -10,7 +12,7 @@ OS=$1
 if [ $# -gt 1 ]; then
   shift
   COMMAND=$*
-  if [[ $COMMAND != bash ]]; then
+  if [[ $COMMAND != bash ]] && [[ $COMMAND != /getssl/test/debug-test.sh* ]]; then
     if [[ $COMMAND != "bats /getssl/test"* ]]; then
       if [[ $COMMAND == /getssl/test* ]]; then
         COMMAND="bats $COMMAND"
@@ -27,6 +29,7 @@ if [ $# -gt 1 ]; then
 else
   COMMAND="bats /getssl/test --timing"
 fi
+echo "Running $COMMAND"
 
 REPO=""
 if [ -n "$GITHUB_REPOSITORY" ] ; then

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -10,6 +10,18 @@ OS=$1
 if [ $# -gt 1 ]; then
   shift
   COMMAND=$*
+  if [[ $COMMAND != bash ]]; then
+    if [[ $COMMAND != "bats /getssl/test"* ]]; then
+      if [[ $COMMAND == /getssl/test* ]]; then
+        COMMAND="bats $COMMAND"
+      else
+        COMMAND="bats /getssl/test/$COMMAND"
+      fi
+    fi
+    if [[ $COMMAND != *.bats ]]; then
+      COMMAND="${COMMAND}.bats"
+    fi
+  fi
 else
   COMMAND="bats /getssl/test --timing"
 fi

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -14,6 +14,8 @@ if [ $# -gt 1 ]; then
     if [[ $COMMAND != "bats /getssl/test"* ]]; then
       if [[ $COMMAND == /getssl/test* ]]; then
         COMMAND="bats $COMMAND"
+      elif [[ $COMMAND == test/* ]]; then
+        COMMAND="bats /getssl/$COMMAND"
       else
         COMMAND="bats /getssl/test/$COMMAND"
       fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -16,9 +16,11 @@ check_github_quota() {
   need="$1"
   echo "# Checking github limits"
   while true ; do
+    # shellcheck disable=SC2086
     limits="$(curl ${_NOMETER:---silent} --user-agent "srvrco/getssl/github-actions" -H 'Accept: application/vnd.github.v3+json' "$LIMIT_API")"
-    echo "# limits = $limits"
+    # save error code before calling echo
     errcode=$?
+    echo "# limits = $limits"
     if [[ $errcode -eq 60 ]]; then
       echo "curl needs updating, your version does not support SNI (multiple SSL domains on a single IP)"
       exit 1
@@ -41,7 +43,7 @@ check_github_quota() {
       echo "# sleeping $(( reset - now )) seconds for GitHub quota"
       sleep "$(( reset - now ))"
       now="$(date +%s)"
-   done
+    done
   done
 }
 

--- a/test/u2-test-get_auth_dns-drill.bats
+++ b/test/u2-test-get_auth_dns-drill.bats
@@ -136,6 +136,7 @@ teardown() {
     CHECK_PUBLIC_DNS_SERVER=false
     CHECK_ALL_AUTH_DNS=false
 
+    echo "# Checking we can find the primary_ns server"
     run get_auth_dns www.duckdns.org
 
     # Assert that we've found the primary_ns server
@@ -146,11 +147,13 @@ teardown() {
     assert_line --regexp 'Using drill.* NS'
 
     # Check all Authoritive DNS servers are returned if requested
+    echo "# Checking all authoritive DNS servers are returned if requested"
     CHECK_ALL_AUTH_DNS=true
     run get_auth_dns www.duckdns.org
     assert_output --regexp 'set primary_ns = ns.*\.awsdns.*\.net'
 
     # Check that we also check the public DNS server if requested
+    echo "# Checking we use the public DNS server if requested"
     CHECK_PUBLIC_DNS_SERVER=true
     run get_auth_dns www.duckdns.org
     assert_output --regexp 'set primary_ns = ns.*\.awsdns.*\.net 1\.0\.0\.1'

--- a/test/u2-test-get_auth_dns-drill.bats
+++ b/test/u2-test-get_auth_dns-drill.bats
@@ -66,14 +66,14 @@ teardown() {
     run get_auth_dns ubuntu-getssl.ignorelist.com
 
     # Assert that we've found the primary_ns server
-    assert_output --regexp 'set primary_ns = ns[1-3]+\.afraid\.org'
+    assert_output --regexp 'set primary_ns = ns[1-4]+\.afraid\.org'
     # Assert that we had to use drill NS
     assert_line --regexp 'Using drill.* NS'
 
     # Check all Authoritive DNS servers are returned if requested
     CHECK_ALL_AUTH_DNS=true
     run get_auth_dns ubuntu-getssl.ignorelist.com
-    assert_output --regexp 'set primary_ns = (ns[1-3]+\.afraid\.org ?)+'
+    assert_output --regexp 'set primary_ns = (ns[1-4]+\.afraid\.org ?)+'
 }
 
 

--- a/test/u8-test-get_auth_dns-cname-nslookup.bats
+++ b/test/u8-test-get_auth_dns-cname-nslookup.bats
@@ -22,9 +22,9 @@ setup() {
     NSLOOKUP_VERSION=$(echo "" | nslookup -version 2>/dev/null | awk -F"[ -]" '{ print $2 }')
     # Version 9.11.3 on Ubuntu -debug doesn't work inside docker in my test env, version 9.16.1 does
     if [[ "${NSLOOKUP_VERSION}" != "Invalid" ]] && check_version "${NSLOOKUP_VERSION}" "9.11.4" ; then
-      DNS_CHECK_OPTIONS="$DNS_CHECK_OPTIONS -debug"
+        DNS_CHECK_OPTIONS="$DNS_CHECK_OPTIONS -debug"
     else
-      skip "This version of nslookup either doesn't support -debug or it doesn't work in local docker"
+        skip "This version of nslookup either doesn't support -debug or it doesn't work in local docker"
     fi
 }
 


### PR DESCRIPTION
This change is to help with non-compliant ACME implementations that pass `"wildcard": false` in authorization responses instead of leaving it off entirely as RFC8555 requires. See #843 for more details.