### PR TITLE
add newlines to ca_all_loc

### DIFF
--- a/getssl
+++ b/getssl
@@ -291,6 +291,7 @@
 # 2023-02-22 Remove cronie from deb package dependencies (2.48)
 # 2024-03-18 Refresh the TXT record if a CNAME is found (JoergBruce #828) (2.49)
 # 2024-03-26 Test for "true" in wildcard property of authorization responses
+# 2024-10-16 Add newlines to /directory response (#765)(#859)
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in

--- a/getssl
+++ b/getssl
@@ -2312,6 +2312,8 @@ obtain_ca_resource_locations()
     fi
 
     debug "ca_all_loc from ${CA}${suffix} gives $ca_all_loc"
+    ca_all_loc=${ca_all_loc//,/,$'\n'}
+
     # APIv1
     URL_new_reg=$(echo "$ca_all_loc" | grep "new-reg" | awk -F'"' '{print $4}')
     URL_new_authz=$(echo "$ca_all_loc" | grep "new-authz" | awk -F'"' '{print $4}')

--- a/test/u9-test-ca-newlines.bats
+++ b/test/u9-test-ca-newlines.bats
@@ -1,0 +1,56 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
+
+    . /getssl/getssl --source
+#    find_dns_utils
+    _USE_DEBUG=1
+}
+
+
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+}
+
+
+@test "Check obtain_ca_resource_locations for LetsEncrypt (uses newlines)" {
+    # LetsEncrypt CA splits the directory with comma then newline
+    CA="https://acme-staging-v02.api.letsencrypt.org/directory"
+    obtain_ca_resource_locations
+
+    assert_equal $API 2
+    assert_not_equal $URL_newAccount $URL_newNonce
+    assert_not_equal $URL_newNonce $URL_newOrder
+    assert_not_equal $URL_newOrder $URL_revole
+}
+
+
+@test "Check obtain_ca_resource_locations for Sectigo (no newlines)" {
+    # Sectigo CA splits the directory with commas
+    CA="https://acme.enterprise.sectigo.com"
+    obtain_ca_resource_locations
+
+    assert_equal $API 2
+    assert_not_equal $URL_newAccount $URL_newNonce
+    assert_not_equal $URL_newNonce $URL_newOrder
+    assert_not_equal $URL_newOrder $URL_revole
+}
+
+
+@test "Check obtain_ca_resource_locations for BuyPass (no newlines)" {
+    # BuyPass CA splits the directory with commas
+    CA="https://api.test4.buypass.no/acme"
+    obtain_ca_resource_locations
+
+    assert_equal $API 2
+    assert_not_equal $URL_newAccount $URL_newNonce
+    assert_not_equal $URL_newNonce $URL_newOrder
+    assert_not_equal $URL_newOrder $URL_revole
+}


### PR DESCRIPTION
If the properties in /directory are not separated by newlines the URL_ variables will all contain the first URL.
To combat this this PR just adds newlines after every ",".

This fixes #765 and fixes #859.