### PR TITLE
Fix cPanel Scripts

### DIFF
--- a/dns_scripts/dns_add_cpanel
+++ b/dns_scripts/dns_add_cpanel
@@ -61,11 +61,11 @@ fi
 
 # If no existing record, create a new TXT record, otherwise edit the existing record
 if [[ "$resp" == *\"data\":[]* ]]; then
-  request_params="&cpanel_jsonapi_func=add_zone_record&domain=$domain&type=TXT&name=_acme-challenge$name&txtdata=$token"
+  request_params="&cpanel_jsonapi_func=add_zone_record&domain=${domain}&type=TXT&name=_acme-challenge&txtdata=${token}"
 else
   # shellcheck disable=SC2001
   line=$(echo "$resp" | sed -e 's/.*line":\([0-9]*\),.*/\1/')
-  request_params="&cpanel_jsonapi_func=edit_zone_record&domain=$domain&type=TXT&name=_acme-challenge$name&txtdata=${token}&line=${line}"
+  request_params="&cpanel_jsonapi_func=edit_zone_record&domain=${domain}&type=TXT&name=_acme-challenge&txtdata=${token}&line=${line}"
 fi
 resp=$(curl --silent "${curl_params[@]}" "$request_func$request_params")
 

--- a/dns_scripts/dns_del_cpanel
+++ b/dns_scripts/dns_del_cpanel
@@ -58,7 +58,7 @@ fi
 line=$(echo "$resp" | sed -e 's/.*line":\([0-9]*\),.*/\1/')
 if [[ "$line" != "" ]]; then
   # Delete the challenge token
-  request_params="&cpanel_jsonapi_func=remove_zone_record&domain=$domain&type=TXT&name=_acme-challenge$name&line=$line"
+  request_params="&cpanel_jsonapi_func=remove_zone_record&domain=${domain}&type=TXT&name=_acme-challenge&line=${line}"
   resp=$(curl --silent "${curl_params[@]}" "$request_func$request_params")
 fi
 

--- a/getssl
+++ b/getssl
@@ -293,6 +293,7 @@
 # 2024-03-26 Test for "true" in wildcard property of authorization responses
 # 2024-10-16 Add newlines to /directory response (#765)(#859)
 # 2025-06-18 Support profiles
+# 2025-12-02 Fix cPanel support for API zone record updates and wildcard domain support
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in
@@ -301,7 +302,7 @@ esac
 
 PROGNAME=${0##*/}
 PROGDIR="$(cd "$(dirname "$0")" || exit; pwd -P;)"
-VERSION="2.49"
+VERSION="2.50"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096

--- a/other_scripts/cpanel_cert_upload
+++ b/other_scripts/cpanel_cert_upload
@@ -5,6 +5,7 @@
 # use with RELOAD_CMD="${HOME}/cpanel_cert_upload domain.com"
 
 domain="$1"
+nowild=$(echo "${1//\*\./}")
 
 rawurlencode() {
   local string
@@ -28,4 +29,4 @@ ecert=$( rawurlencode "${HOME}/.getssl/${domain}/${domain}.crt" )
 ekey=$( rawurlencode "${HOME}/.getssl/${domain}/${domain}.key" )
 echain=$( rawurlencode "${HOME}/.getssl/${domain}/chain.crt" )
 
-uapi SSL install_ssl domain="${domain}" cert="${ecert}" key="${ekey}" cabundle="${echain}"
+uapi SSL install_ssl domain="${nowild}" cert="${ecert}" key="${ekey}" cabundle="${echain}"


### PR DESCRIPTION
After debugging running cron jobs against cPanel, these changes fix a few things:

- Handle wild card domain certificates associated with root domain
- Fixes `curl` cPanel API `add_zone_record` parameters
- Fixes `curl` cPanel API `edit_zone_record` parameters
- Fixes `curl` cPanel API `remove_zone_record` parameters