### PR TITLE
Case-insensitive Replay-Nonce headers

### DIFF
--- a/getssl
+++ b/getssl
@@ -293,6 +293,7 @@
 # 2024-03-26 Test for "true" in wildcard property of authorization responses
 # 2024-10-16 Add newlines to /directory response (#765)(#859)
 # 2025-06-18 Support profiles
+# 2025-07-28 Accept lowercase replay-nonce headers (#884)
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in
@@ -2721,9 +2722,9 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
   # get nonce from ACME server
   if [[ $API -eq 1 ]]; then
     nonceurl="$CA/directory"
-    nonce=$($CURL -I "$nonceurl" | grep "^Replay-Nonce:" | awk '{print $2}' | tr -d '\r\n ')
+    nonce=$($CURL -I "$nonceurl" | grep -i "^Replay-Nonce:" | awk '{print $2}' | tr -d '\r\n ')
   else # APIv2
-    nonce=$($CURL -I "$URL_newNonce" | grep "^Replay-Nonce:" | awk '{print $2}' | tr -d '\r\n ')
+    nonce=$($CURL -I "$URL_newNonce" | grep -i "^Replay-Nonce:" | awk '{print $2}' | tr -d '\r\n ')
   fi
 
   nonceproblem="true"


### PR DESCRIPTION
Split off from #859; I believe this is a separate bug which still exists:

> Another potential bug is [the checking of the Replay-Nonce header](https://github.com/srvrco/getssl/blob/c3f9d29375a93ba76a7cbc250aaea147da68923e/getssl#L2516). I noticed in the certbot debug log (which was successful) that Sectigo was sending a lowercase **replay-nonce** header.

It appears that [further down it _does_ use `grep -i`](https://github.com/srvrco/getssl/blob/0e802e7c2c8a8f1a36b143304739856988e118d8/getssl#L2828), so in effect it's just causing an initial "bad nonce" and will succeed on retry, but we may as well fix the first attempt.