### PR TITLE
DNS: Add Hetzner cloud

### DIFF
--- a/dns_scripts/dns_add_hetzner_cloud
+++ b/dns_scripts/dns_add_hetzner_cloud
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="https://api.hetzner.cloud/v1"
+api_key=${HETZNER_KEY:-''}
+zone_id=${HETZNER_ZONE_ID:-''}
+zone_name=${HETZNER_ZONE_NAME:-''}
+
+# Verify that required parameters are set
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$HETZNER_KEY" ]]; then
+  echo "HETZNER_KEY variable not set"
+  exit 1
+fi
+if [[ -z "$HETZNER_ZONE_ID" && -z "$HETZNER_ZONE_NAME" ]] ; then
+  echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
+  exit 1
+fi
+
+# Get Zone ID if not set
+if [[ -z "$HETZNER_ZONE_ID" ]] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$zone_name" -H 'Authorization: Bearer '"$api_key"'' | jq -r '.zones[0].id')
+  if [[ "$zone_id" == "null" ]] ; then
+    echo "Zone ID not found"
+    exit 1
+  fi
+fi
+
+relative=$(echo "$fulldomain" | awk -F. 'NF>2 {for(i=1;i<=NF-2;i++) printf "%s%s", $i, (i==NF-2?"":".")}')
+txtname="_acme-challenge.${relative}"
+
+payload=$(jq -n \
+  --arg token "$token" \
+  '{
+    ttl: 60,
+    records: [
+      { value: ("\"" + $token + "\"") }
+    ]
+  }')
+
+# Create TXT record
+response=$(curl -s -o /dev/null -w '%{http_code}' \
+  -X POST "$api_url/zones/$zone_id/rrsets/$txtname/TXT/actions/add_records" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $api_key" \
+  -d "$payload")
+
+if [[ "$response" != "201" ]] ; then
+  echo "Record not created"
+  echo "Response code: $response"
+  exit 1
+fi

--- a/dns_scripts/dns_add_hetzner_cloud
+++ b/dns_scripts/dns_add_hetzner_cloud
@@ -34,8 +34,17 @@ if [[ -z "$HETZNER_ZONE_ID" ]] ; then
   fi
 fi
 
-relative=$(echo "$fulldomain" | awk -F. 'NF>2 {for(i=1;i<=NF-2;i++) printf "%s%s", $i, (i==NF-2?"":".")}')
-txtname="_acme-challenge.${relative}"
+# Get Zone name if not set
+if [[ -z "$zone_name" ]] ; then
+  zone_name=$(curl --silent -X GET "$api_url/zones/$zone_id" -H 'Authorization: Bearer '"$api_key"'' | jq -r '.zone.name')
+  if [[ "$zone_name" == "null" ]] ; then
+    echo "Zone name not found"
+    exit 1
+  fi
+fi
+
+txtname="_acme-challenge.$fulldomain"
+txtname="${txtname%."$zone_name"}"
 
 payload=$(jq -n \
   --arg token "$token" \

--- a/dns_scripts/dns_del_hetzner_cloud
+++ b/dns_scripts/dns_del_hetzner_cloud
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="https://api.hetzner.cloud/v1"
+api_key=${HETZNER_KEY:-''}
+zone_id=${HETZNER_ZONE_ID:-''}
+zone_name=${HETZNER_ZONE_NAME:-''}
+
+# Verify that required parameters are set
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$HETZNER_KEY" ]]; then
+  echo "HETZNER_KEY variable not set"
+  exit 1
+fi
+if [[ -z "$HETZNER_ZONE_ID" && -z "$HETZNER_ZONE_NAME" ]] ; then
+  echo "HETZNER_ZONE_ID and HETZNER_ZONE_NAME variables not set"
+  exit 1
+fi
+
+# Get Zone ID if not set
+if [[ -z "$HETZNER_ZONE_ID" ]] ; then
+  zone_id=$(curl --silent -X GET "$api_url/zones?name=$zone_name" -H 'Authorization: Bearer '"$api_key"'' | jq -r '.zones[0].id')
+  if [[  "$zone_id" == "null" ]] ; then
+    echo "Zone by name not found"
+    exit 1
+  fi
+fi
+
+relative=$(echo "$fulldomain" | awk -F. 'NF>2 {for(i=1;i<=NF-2;i++) printf "%s%s", $i, (i==NF-2?"":".")}')
+txtname="_acme-challenge.${relative}"
+
+# Delete TXT record
+payload=$(jq -n \
+  --arg token "$token" \
+  '{
+    records: [
+      { value: ("\"" + $token + "\"") }
+    ]
+  }')
+
+response=$(curl -s -w '%{http_code}' \
+  -X POST "$api_url/zones/$zone_id/rrsets/$txtname/TXT/actions/remove_records" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $api_key" \
+  -d "$payload" \
+  -o /dev/null)
+
+if [[ "$response" != "201" ]] ; then
+  echo "Record not deleted"
+  echo "Response code: $response"
+  exit 1
+fi
+

--- a/dns_scripts/dns_del_hetzner_cloud
+++ b/dns_scripts/dns_del_hetzner_cloud
@@ -34,8 +34,17 @@ if [[ -z "$HETZNER_ZONE_ID" ]] ; then
   fi
 fi
 
-relative=$(echo "$fulldomain" | awk -F. 'NF>2 {for(i=1;i<=NF-2;i++) printf "%s%s", $i, (i==NF-2?"":".")}')
-txtname="_acme-challenge.${relative}"
+# Get Zone name if not set
+if [[ -z "$zone_name" ]] ; then
+  zone_name=$(curl --silent -X GET "$api_url/zones/$zone_id" -H 'Authorization: Bearer '"$api_key"'' | jq -r '.zone.name')
+  if [[ "$zone_name" == "null" ]] ; then
+    echo "Zone name not found"
+    exit 1
+  fi
+fi
+
+txtname="_acme-challenge.$fulldomain"
+txtname="${txtname%."$zone_name"}"
 
 # Delete TXT record
 payload=$(jq -n \

--- a/test/u6-test-combined-directory.bats
+++ b/test/u6-test-combined-directory.bats
@@ -9,6 +9,7 @@ CA="https://api.test4.buypass.no/acme"
 
 # This is run for every test
 setup() {
+    skip "buypass.no has stopped selling SSL certificates"
     [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
 
     . /getssl/getssl --source

--- a/test/u9-test-ca-newlines.bats
+++ b/test/u9-test-ca-newlines.bats
@@ -10,7 +10,6 @@ setup() {
     [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
 
     . /getssl/getssl --source
-#    find_dns_utils
     _USE_DEBUG=1
 }
 
@@ -35,18 +34,6 @@ teardown() {
 @test "Check obtain_ca_resource_locations for Sectigo (no newlines)" {
     # Sectigo CA splits the directory with commas
     CA="https://acme.enterprise.sectigo.com"
-    obtain_ca_resource_locations
-
-    assert_equal $API 2
-    assert_not_equal $URL_newAccount $URL_newNonce
-    assert_not_equal $URL_newNonce $URL_newOrder
-    assert_not_equal $URL_newOrder $URL_revole
-}
-
-
-@test "Check obtain_ca_resource_locations for BuyPass (no newlines)" {
-    # BuyPass CA splits the directory with commas
-    CA="https://api.test4.buypass.no/acme"
     obtain_ca_resource_locations
 
     assert_equal $API 2


### PR DESCRIPTION
Getssl supports Hetzner DNS API, but they are phrasing out[^1] the DNS API.

This adds support for Hetzner's Cloud API[^2] to manage zones to add and remove ACME DNS records.

[^1]: https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process/
[^2]: https://docs.hetzner.cloud/reference/cloud#tag/zones

Similar to the Hetzner DNS API integration, this works by setting additional environment variables either within the global `.getssl` config file, or certificate-specific `getssl.cfg` file.

 - `HETZNER_KEY`: Required, set project-specific API key.
 - `HETZNER_ZONE_ID`: The numeric zone ID
 - `HETZNER_ZONE_NAME`: If `HETZNER_ZONE_ID` is not provided, the zone ID will be fetched by searching for this name. This may not work reliably, and setting `HETZNER_ZONE_ID` is recommended.

Either `HETZNER_ZONE_ID` or `HETZNER_ZONE_ID` _must_ be set.

The system also must have `jq` installed.