### PR TITLE
Add ARI support to getssl

### DIFF
--- a/getssl
+++ b/getssl
@@ -1283,16 +1283,26 @@ renew_ari() { # Return "1" if ARI says we should renew
   # of the authority key identifier and serial number
 
   aki=$(openssl x509 -noout -text -in "$CERT_FILE" 2>/dev/null |
-        grep "Authority Key Identifier" -A1 | \
-	grep -E '^[A-Fa-f0-9: 	]+$' | \
-	tr -d ':' | \
-	hex2bin | \
-	urlbase64)
+    grep "Authority Key Identifier" -A1 | \
+    sed 's/^.*keyid://' | \
+    grep -E '^[A-Fa-f0-9: 	]+$' | \
+    tr -d ':' | \
+    hex2bin | \
+    urlbase64)
 
+  # Extract the hex serial number from openssl output. OpenSSL 3.x puts it
+  # on the same line as "Serial Number:" (as "(0xHEX)"), while older
+  # versions put colon-separated hex on the following line.
   serial=$(openssl x509 -noout -text -in "$CERT_FILE" 2>/dev/null | \
-	   grep "Serial Number" -A1 | \
-	   grep -E '^[A-Fa-f0-9:   ]+$' | \
-	   tr -d ': 	')
+     grep "Serial Number" | \
+     grep -oiE '0x[0-9a-f]+' | \
+     cut -dx -f2)
+  if [[ -z "$serial" ]]; then
+    serial=$(openssl x509 -noout -text -in "$CERT_FILE" 2>/dev/null | \
+      grep "Serial Number" -A1 | \
+      grep -E '^[A-Fa-f0-9:   ]+$' | \
+      tr -d ': 	')
+  fi
 
   # If the high bit is set then we need to prepend an extra byte so
   # the DER encoding is positive
@@ -1320,7 +1330,7 @@ renew_ari() { # Return "1" if ARI says we should renew
   debug "Renewal window starts at $_ARI_STARTTIME"
 
   if [[ "$(date +%s)" -gt $(date_rfc3339 "$_ARI_STARTTIME") ]]; then
-    debug "Within ARI rewewal window, using ARI"
+    debug "Within ARI renewal window, using ARI"
     _REPLACES="${aki}.${serialb64}"
     return 0
   fi
@@ -1343,7 +1353,9 @@ date_rfc3339() { # convert rfc3339 format date into epoch time
   elif [[ "$os" == "mac" ]]; then
     date -j -f "%Y-%m-%dT%H:%M:%S%z" "$convdate" +%s
   elif [[ "$os" == "busybox" ]]; then
-    date -D "%Y-%m-%dT%H:%M:%S%z" -d "$convdate" +%s
+    # busybox doesn't support timezones in the input format
+    convdate=$(printf "%s\n" "$convdate" | sed 's/[+-][0-9]\{4\}$//')
+    date -D "%Y-%m-%dT%H:%M:%S" -d "$convdate" +%s
   else
     date -d "$convdate" +%s
   fi
@@ -1360,7 +1372,6 @@ date_epoc() { # convert the date into epoch time
   else
     date -d "$1" +%s
   fi
-
 }
 
 date_fmt() { # format date from epoc time to YYYY-MM-DD
@@ -3678,10 +3689,10 @@ if [[ -s "$CERT_FILE" ]] && [[ $_SHOW_ACCOUNT_ID -eq 0 ]]; then
     if [[ -n "$URL_renewInfo" ]] && [[ "true" == "$ARI_ENABLE" ]]; then
       if renew_ari "$enddate_s"; then
         debug "Renewing via ARI"
-	ari=1
+        ari=1
       else
         debug "ARI is supported, but not reached start of window"
-	ari=0
+        ari=0
       fi
     else
       ari=-1
@@ -3693,9 +3704,9 @@ if [[ -s "$CERT_FILE" ]] && [[ $_SHOW_ACCOUNT_ID -eq 0 ]]; then
       else
         if [[ $ari -eq -1 ]]; then
           info "${DOMAIN}: certificate is valid for more than $RENEW_ALLOW days (until $enddate)"
-	else
-	  info "${DOMAIN}: certificate has not yet reached ARI renewal window (window starts at $_ARI_STARTTIME)"
-	fi
+        else
+          info "${DOMAIN}: certificate has not yet reached ARI renewal window (window starts at $_ARI_STARTTIME)"
+	      fi
         # everything is OK, so exit, if requested with the --notify-valid, exit with code 2
         graceful_exit $_NOTIFY_VALID
       fi
@@ -3758,21 +3769,21 @@ info "Registering account"
 # send the request to the ACME server.
 if [[ $API -eq 1 ]]; then
   if [[ "$ACCOUNT_EMAIL" ]] ; then
-  	regjson='{"resource": "new-reg", "contact": ["mailto: '$ACCOUNT_EMAIL'"], "agreement": "'$AGREEMENT'"}'
+    regjson='{"resource": "new-reg", "contact": ["mailto: '$ACCOUNT_EMAIL'"], "agreement": "'$AGREEMENT'"}'
   else
-  	regjson='{"resource": "new-reg", "agreement": "'$AGREEMENT'"}'
+    regjson='{"resource": "new-reg", "agreement": "'$AGREEMENT'"}'
   fi
   send_signed_request "$URL_new_reg"  "$regjson"
 elif [[ $API -eq 2 ]]; then
   if [[ "$ACCOUNT_EMAIL" ]] ; then
-  	regjson='{"termsOfServiceAgreed": true, "contact": ["mailto: '$ACCOUNT_EMAIL'"]}'
+    regjson='{"termsOfServiceAgreed": true, "contact": ["mailto: '$ACCOUNT_EMAIL'"]}'
   else
-  	regjson='{"termsOfServiceAgreed": true}'
+    regjson='{"termsOfServiceAgreed": true}'
   fi
   send_signed_request "$URL_newAccount"  "$regjson"
 else
-	debug "cant determine account API"
-	graceful_exit
+  debug "cant determine account API"
+  graceful_exit
 fi
 
 if [[ "$code" == "" ]] || [[ "$code" == '201' ]] ; then

--- a/getssl
+++ b/getssl
@@ -1315,6 +1315,7 @@ renew_ari() { # Return "1" if ARI says we should renew
 
   debug "Authority key id is $aki, serial is $serialb64"
 
+  # shellcheck disable=SC2086
   response=$(curl ${_NOMETER} --user-agent "$CURL_USERAGENT" --silent "${URL_renewInfo}/${aki}.${serialb64}")
 
   debug "ARI response is $response"

--- a/getssl
+++ b/getssl
@@ -1341,6 +1341,7 @@ renew_ari() { # Return "1" if ARI says we should renew
 }
 
 date_rfc3339() { # convert rfc3339 format date into epoch time
+  # shellcheck disable=SC2018,SC2019
   convdate=$(printf "%s\n" "$1" | tr a-z A-Z)
   if [[ "${convdate: -1:1}" == 'Z' ]]; then
     convdate="${convdate:0:${#convdate}-1}+0000"

--- a/getssl
+++ b/getssl
@@ -308,6 +308,7 @@ VERSION="2.49"
 ACCOUNT_KEY_LENGTH=4096
 ACCOUNT_KEY_TYPE="rsa"
 ACME_RESPONSE_PENDING_WAIT=5
+ARI_ENABLE="true"
 CA_CERT_LOCATION=""
 CA="https://acme-staging-v02.api.letsencrypt.org/directory"
 CHALLENGE_CHECK_TYPE="http"
@@ -365,6 +366,7 @@ DNS_EXTRA_WAIT=60               # How long to wait after the DNS entries are vis
 DNS_WAIT_RETRY_ADD="false"      # Try the dns_add_command again if the DNS record hasn't updated
 
 # Private variables
+_ARI_STARTTIME=""
 _CHECK_ALL=0
 _CREATE_CONFIG=0
 _CURL_VERSION=""
@@ -375,6 +377,7 @@ _NOMETER=""
 _QUIET=0
 _RECREATE_CSR=0
 _REDIRECT_OUTPUT="1>/dev/null 2>&1"
+_REPLACES=""
 _REVOKE=0
 _SHOW_ACCOUNT_ID=0
 _TEST_SKIP_CNAME_CALL=0
@@ -1212,12 +1215,13 @@ create_order() {
     dstring="${dstring}{\"type\":\"dns\",\"value\":\"$d\"},"
   done
   dstring="${dstring::${#dstring}-1}]"
+  replaces="${_REPLACES:+, \"replaces\": \"${_REPLACES}\"}"
 
   # Check if the server supports profiles using the URL_profiles variable
   if [[ -z "$URL_profiles" ]]; then
-    request="{\"identifiers\": $dstring}"
+    request="{\"identifiers\": $dstring$replaces}"
   else
-    request="{\"identifiers\": $dstring, \"profile\": \"$PROFILE\"}"
+    request="{\"identifiers\": $dstring, \"profile\": \"$PROFILE\"$replaces}"
   fi
   send_signed_request "$URL_newOrder" "$request"
   OrderLink=$(echo "$responseHeaders" | grep -i location | awk '{print $2}'| tr -d '\r\n ')
@@ -1264,6 +1268,84 @@ create_order() {
         debug "deactivate list is now $deactivate_url_list"
       fi
     done
+  fi
+}
+
+renew_ari() { # Return "1" if ARI says we should renew
+  # If cert has expired, don't fetch ARI info and just say we should renew
+
+  if [[ "$1" -lt "$(date +s)" ]]; then
+    debug "Certificate expired, not fetching ARI info"
+    return 0
+  fi
+
+  # Construct the certificate identifier which is the base64url encoding
+  # of the authority key identifier and serial number
+
+  aki=$(openssl x509 -noout -text -in "$CERT_FILE" 2>/dev/null |
+        grep "Authority Key Identifier" -A1 | \
+	grep -E '^[A-Fa-f0-9: 	]+$' | \
+	tr -d ':' | \
+	hex2bin | \
+	urlbase64)
+
+  serial=$(openssl x509 -noout -text -in "$CERT_FILE" 2>/dev/null | \
+	   grep "Serial Number" -A1 | \
+	   grep -E '^[A-Fa-f0-9:   ]+$' | \
+	   tr -d ': 	')
+
+  # If the high bit is set then we need to prepend an extra byte so
+  # the DER encoding is positive
+
+  if printf "%s\n" "$serial" | grep -q -E '^[89ABCDEFabcdef]'; then
+    serial="00$serial"
+  fi
+
+  serialb64=$(printf "%s\n" "$serial" | hex2bin | urlbase64)
+
+  debug "Authority key id is $aki, serial is $serialb64"
+
+  response=$(curl ${_NOMETER} --user-agent "$CURL_USERAGENT" --silent "${URL_renewInfo}/${aki}.${serialb64}")
+
+  debug "ARI response is $response"
+
+  _ARI_STARTTIME=$(json_get "$response" suggestedWindow start)
+
+  if [[ -z "$_ARI_STARTTIME" ]]; then
+    info "Warning: ARI query returned $response"
+    info "Not processing ARI renewal info"
+    return 1
+  fi
+
+  debug "Renewal window starts at $_ARI_STARTTIME"
+
+  if [[ "$(date +%s)" -gt $(date_rfc3339 "$_ARI_STARTTIME") ]]; then
+    debug "Within ARI rewewal window, using ARI"
+    _REPLACES="${aki}.${serialb64}"
+    return 0
+  fi
+
+  debug "Not within ARI renewal window"
+
+  return 1
+}
+
+date_rfc3339() { # convert rfc3339 format date into epoch time
+  convdate=$(printf "%s\n" "$1" | tr a-z A-Z)
+  if [[ "${convdate: -1:1}" == 'Z' ]]; then
+    convdate="${convdate:0:${#convdate}-1}+0000"
+  else
+    convdate=$(printf "%s\n" "$convdate" | sed -e 's/:\([0-9][0-9]\)$/\1/')
+  fi
+
+  if [[ "$os" == "bsd" ]]; then
+    date -j -f "%Y-%m-%dT%H:%M:%S%z" "$convdate" +%s
+  elif [[ "$os" == "mac" ]]; then
+    date -j -f "%Y-%m-%dT%H:%M:%S%z" "$convdate" +%s
+  elif [[ "$os" == "busybox" ]]; then
+    date -D "%Y-%m-%dT%H:%M:%S%z" -d "$convdate" +%s
+  else
+    date -d "$convdate" +%s
   fi
 }
 
@@ -2512,6 +2594,7 @@ obtain_ca_resource_locations()
     URL_newNonce=$(echo "$ca_all_loc" | grep "newNonce" | awk -F'"' '{print $4}')
     URL_newOrder=$(echo "$ca_all_loc" | grep "newOrder" | awk -F'"' '{print $4}')
     URL_revoke=$(echo "$ca_all_loc" | grep "revokeCert" | awk -F'"' '{print $4}')
+    URL_renewInfo=$(echo "$ca_all_loc" | grep "renewalInfo" | awk -F'"' '{print $4}')
 
     URL_profiles=""
     # Check if we have a profiles element
@@ -3046,6 +3129,12 @@ write_getssl_template() { # write out the main template file
 	# Several (ssh) commands may be given using a bash array:
 	# RELOAD_CMD=('ssh:sshuserid@server5:systemctl reload httpd' 'logger getssl for server5 efficient.')
 	#RELOAD_CMD=""
+
+	# If your ACME server supports ARI, then use that to make the decision
+	# about whether or not to renew your certificate.  If this is set to "true"
+	# and the ACME server supports ARI, then the RENEW_ALLOW setting will have
+	# no effect.
+	ARI_ENABLE="true"
 
 	# The time period within which you want to allow renewal of a certificate
 	#  this prevents hitting some of the rate limits.
@@ -3586,12 +3675,27 @@ if [[ -s "$CERT_FILE" ]] && [[ $_SHOW_ACCOUNT_ID -eq 0 ]]; then
   debug "existing cert is for domains: ${sorted_sanlist}"
   if [[ "$enddate" != "-" ]]; then
     enddate_s=$(date_epoc "$enddate")
-    if [[ $(date_renew) -lt "$enddate_s" ]] && [[ $_FORCE_RENEW -ne 1 ]] && [[ "$existing_sanlist" == "$sorted_sanlist" ]]; then
+    if [[ -n "$URL_renewInfo" ]] && [[ "true" == "$ARI_ENABLE" ]]; then
+      if renew_ari "$enddate_s"; then
+        debug "Renewing via ARI"
+	ari=1
+      else
+        debug "ARI is supported, but not reached start of window"
+	ari=0
+      fi
+    else
+      ari=-1
+    fi
+    if [[ $ari -eq 0 || ( $ari -eq -1 && $(date_renew) -lt "$enddate_s" ) ]] && [[ $_FORCE_RENEW -ne 1 ]] && [[ "$existing_sanlist" == "$sorted_sanlist" ]]; then
       issuer=$(openssl x509 -in "$CERT_FILE" -noout -issuer 2>/dev/null)
       if [[ "$issuer" == *"Fake LE Intermediate"* ]] && [[ "$CA" == "https://acme-v02.api.letsencrypt.org" ]]; then
         debug "upgrading from fake cert to real"
       else
-        info "${DOMAIN}: certificate is valid for more than $RENEW_ALLOW days (until $enddate)"
+        if [[ $ari -eq -1 ]]; then
+          info "${DOMAIN}: certificate is valid for more than $RENEW_ALLOW days (until $enddate)"
+	else
+	  info "${DOMAIN}: certificate has not yet reached ARI renewal window (window starts at $_ARI_STARTTIME)"
+	fi
         # everything is OK, so exit, if requested with the --notify-valid, exit with code 2
         graceful_exit $_NOTIFY_VALID
       fi

--- a/test/13-notify-valid.bats
+++ b/test/13-notify-valid.bats
@@ -20,7 +20,7 @@ setup() {
     if [ -n "$STAGING" ]; then
         skip "Using staging server, skipping internal test"
     fi
-    CONFIG_FILE="getssl-http01.cfg"
+    CONFIG_FILE="getssl-http01-no-ari.cfg"
     setup_environment
     init_getssl
     create_certificate

--- a/test/39-private-key-alg-changed.bats
+++ b/test/39-private-key-alg-changed.bats
@@ -23,7 +23,7 @@ teardown_file() {
     if [ -n "$STAGING" ]; then
         skip "Using staging server, skipping internal test"
     fi
-    CONFIG_FILE="getssl-http01.cfg"
+    CONFIG_FILE="getssl-http01-no-ari.cfg"
     setup_environment
     init_getssl
     create_certificate

--- a/test/42-ari-renewal.bats
+++ b/test/42-ari-renewal.bats
@@ -1,0 +1,72 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+setup() {
+    [ ! -f "$BATS_RUN_TMPDIR/failed.skip" ] || skip "skipping tests after first failure"
+}
+
+
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch "$BATS_RUN_TMPDIR/failed.skip"
+}
+
+
+setup_file() {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal ARI/Pebble test"
+    fi
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+}
+
+
+@test "ARI renewal window in the future skips renewal" {
+    # shellcheck disable=SC2034
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    create_certificate
+    assert_success
+    check_output_for_errors
+
+    CERT=${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt
+    ORIGINAL_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+
+    configure_pebble_ari_window future "$CERT"
+    run "${CODE_DIR}/getssl" -U -d "$GETSSL_CMD_HOST"
+
+    assert_success
+    assert_line --partial 'certificate has not yet reached ARI renewal window'
+    assert_line --partial "Not within ARI renewal window"
+    check_output_for_errors
+
+    UPDATED_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+    [[ "$ORIGINAL_SERIAL" = "$UPDATED_SERIAL" ]]
+}
+
+
+@test "ARI renewal window already open renews certificate" {
+    # shellcheck disable=SC2034
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    create_certificate
+    assert_success
+    check_output_for_errors
+
+    CERT=${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt
+    ORIGINAL_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+
+    configure_pebble_ari_window open "$CERT"
+    run "${CODE_DIR}/getssl" -U -d "$GETSSL_CMD_HOST"
+
+    assert_success
+    assert_line --partial "Within ARI renewal window, using ARI"
+    check_output_for_errors
+
+    UPDATED_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+    [[ "$ORIGINAL_SERIAL" != "$UPDATED_SERIAL" ]]
+}

--- a/test/README-Testing.md
+++ b/test/README-Testing.md
@@ -12,6 +12,8 @@ For continuous integration testing we have the following:
 
 Tests can also be triggered manually from the GitHub website.
 
+## Testing using the Staging server
+
 For dynamic DNS tests, you need accounts on duckdns.org and dynu.com, and need to create 4 domain names in each account.
 
 For duckdns.org:
@@ -33,13 +35,15 @@ To run dynamic DNS tests outside the CI environment, you need accounts without \
 
 For individual accounts, \<reponame> is your github account name.
 
-## To run all the tests on a single OS
+## Testing locally using pebble
+
+### To run all the tests on a single OS
 
 1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. Run the test suite ```test/run-test.sh [<os>]```
 3. eg. `test/run-test.sh ubuntu16`
 
-## To run a single bats test on a single OS
+### To run a single bats test on a single OS
 
 1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
 2. ```test/run-test.sh <os> bats <bats test script>```
@@ -52,7 +56,18 @@ For individual accounts, \<reponame> is your github account name.
 3. e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
 4. or (`test/run-test.sh ubuntu /getssl/test/debug-test.sh -d getssl-http01.cfg`)
 
-## TODO
+### To start a shell and debug a test
+
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
+2. ```run-test.sh <os> bash```
+3. `cd /getssl`
+4. `test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
+
+Note: If curl to pebble:14000 fails, change debug-test.sh to use the pebble.minica.pem file
+
+Note: Certificates will be created in /etc/nginx/pki
+
+### TODO
 
 1. Test wildcards
 2. Test SSH, SFTP, SCP

--- a/test/debug-test.sh
+++ b/test/debug-test.sh
@@ -21,9 +21,10 @@ setup_environment 3>&1
 
 # Only add the pebble CA to the cert bundle if using pebble
 if grep -q pebble "${CONFIG_FILE}"; then
-    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+    export CURL_CA_BUNDLE=${INSTALL_DIR}/pebble-ca-bundle.crt
 fi
 
+echo $CURL_CA_BUNDLE
 "${CODE_DIR}/getssl" -U -c "$GETSSL_HOST" 3>&1
 cp "${CONFIG_FILE}" "${INSTALL_DIR}/.getssl/${GETSSL_HOST}/getssl.cfg"
 # shellcheck disable=SC2086

--- a/test/test-config/getssl-dns01.cfg
+++ b/test/test-config/getssl-dns01.cfg
@@ -5,6 +5,7 @@ VALIDATE_VIA_DNS=true
 DNS_WAIT=2
 DNS_WAIT_COUNT=11
 DNS_EXTRA_WAIT=0
+ARI_ENABLE="false"
 
 if [ -z "$STAGING" ]; then
     # Settings for challtestserv dns provider running in local docker

--- a/test/test-config/getssl-http01-dual-rsa-ecdsa-old-nginx.cfg
+++ b/test/test-config/getssl-http01-dual-rsa-ecdsa-old-nginx.cfg
@@ -7,6 +7,7 @@ CA="https://pebble:14000/dir"
 DUAL_RSA_ECDSA="true"
 ACCOUNT_KEY_TYPE="prime256v1"
 PRIVATE_KEY_ALG="prime256v1"
+ARI_ENABLE="false"
 
 # Additional domains - this could be multiple domains / subdomains in a comma separated list
 SANS=""

--- a/test/test-config/getssl-http01-no-ari.cfg
+++ b/test/test-config/getssl-http01-no-ari.cfg
@@ -1,0 +1,35 @@
+# Uncomment and modify any variables you need
+# see https://github.com/srvrco/getssl/wiki/Config-variables for details
+# see https://github.com/srvrco/getssl/wiki/Example-config-files for example configs
+#
+CA="https://pebble:14000/dir"
+
+# Additional domains - this could be multiple domains / subdomains in a comma separated list
+SANS=""
+
+# Acme Challenge Location.
+ACL=('/var/www/html/.well-known/acme-challenge')
+
+#Set USE_SINGLE_ACL="true" to use a single ACL for all checks
+USE_SINGLE_ACL="false"
+
+ARI_ENABLE="false"
+
+# Location for all your certs, these can either be on the server (full path name)
+# or using ssh /sftp as for the ACL
+DOMAIN_CERT_LOCATION="/etc/nginx/pki/server.crt"
+DOMAIN_KEY_LOCATION="/etc/nginx/pki/private/server.key"
+CA_CERT_LOCATION="/etc/nginx/pki/chain.crt"
+DOMAIN_CHAIN_LOCATION="" # this is the domain cert and CA cert
+DOMAIN_PEM_LOCATION="" # this is the domain_key, domain cert and CA cert
+
+# The command needed to reload apache / nginx or whatever you use
+RELOAD_CMD="cp /getssl/test/test-config/nginx-ubuntu-ssl ${NGINX_CONFIG} && /getssl/test/restart-nginx"
+
+# Define the server type and confirm correct certificate is installed
+SERVER_TYPE="https"
+CHECK_REMOTE="true"
+
+if [[ -s "$DOMAIN_DIR/getssl_test_specific.cfg" ]]; then
+    . $DOMAIN_DIR/getssl_test_specific.cfg
+fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -99,6 +99,37 @@ create_certificate() {
   run ${CODE_DIR}/getssl -U -d "$@" "$GETSSL_CMD_HOST"
 }
 
+configure_pebble_ari_window() {
+  local mode cert_file ari_start ari_end ari_response cert_pem payload
+  mode="$1"
+  cert_file="$2"
+  # Note funky date logic to workaround alpine busybox date not supporting "+2 days"
+  # https://stackoverflow.com/questions/72864376/get-the-date-three-days-from-today-with-busybox-date
+  case "$mode" in
+    future)
+      ari_start=$(date -u -d "@$(( $(date +%s) + 2 * 24 * 60 * 60 ))" "+%Y-%m-%dT%H:%M:%SZ")
+      ari_end=$(date -u -d "@$(( $(date +%s) + 3 * 24 * 60 * 60 ))" "+%Y-%m-%dT%H:%M:%SZ")
+      ;;
+    open)
+      ari_start=$(date -u -d "@$(( $(date +%s) - 2 * 24 * 60 * 60 ))" "+%Y-%m-%dT%H:%M:%SZ")
+      ari_end=$(date -u -d "@$(( $(date +%s) + 1 * 24 * 60 * 60 ))" "+%Y-%m-%dT%H:%M:%SZ")
+      ;;
+    *)
+      echo "Unknown ARI mode: $mode" >&2
+      return 1
+      ;;
+  esac
+
+  ari_response=$(printf '{"suggestedWindow":{"start":"%s","end":"%s"}}' "$ari_start" "$ari_end")
+  cert_pem=$(cat "$cert_file")
+  payload=$(jq -n --arg cert "$cert_pem" --arg ari "$ari_response" '{Certificate:$cert,ARIResponse:$ari}')
+
+  curl --silent --show-error --fail \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    https://pebble:15000/set-renewal-info/
+}
+
 init_getssl() {
   # Run initialisation (create account key, etc)
   run ${CODE_DIR}/getssl -U -d -c "$GETSSL_CMD_HOST"


### PR DESCRIPTION
This is a patch implementing ARI (RFC9773) support for ``getssl``. I will admit that I haven't actually tested it yet with a certificate within the ARI renewal window; the shortlived certificate I got will enter the renewal window tomorrow so I will test it then, but I wanted to get some preliminary feedback regarding style, any suggestions for code changes, etc etc.  I took a guess at the busybox support for the ``date`` command.  I am not convinced the logic about using ARI support when you also set RENEW_ALLOW is correct; I welcome any improvements there.

As a side note I saw that profile support was added (yay!) but I am not convinced that you are supposed to pick the first profile in the list provided by the server if the client doesn't specify one. My reading of the I-D is that if you want to take the 'default' you should omit the profile completely and let the server decide. It's entirely possible I am wrong.