### PR TITLE
add support for pdns-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,21 @@ For a more comprehensive installation (e.g. install also helper scripts)
 use the provided Makefile with each release tarball. Use the `install`
 target.
 
+If you install only the standalone `getssl` script to a location such as
+`/usr/local/bin/getssl`, the helper scripts under `dns_scripts/` and
+`other_scripts/` are not installed automatically. In that case, copy any
+helper scripts you need to a suitable location yourself, for example:
+
+```sh
+/usr/local/share/getssl/dns_scripts/
+```
+
+and reference that path in `DNS_ADD_COMMAND` / `DNS_DEL_COMMAND`.
+
+If you install `getssl` from the provided RPM/DEB packages or via the
+`make install` target, the helper scripts are installed alongside it under
+`/usr/share/getssl/dns_scripts/` and `other_scripts/`.
+
 You'll find the latest version in the git repository:
 
 ```sh
@@ -279,6 +294,26 @@ DNS_ADD_COMMAND=/home/root/getssl/dns_scripts/dns_add_cpanel
 DNS_DEL_COMMAND=/home/root/getssl/dns_scripts/dns_del_cpanel
 ```
 
+## PowerDNS
+
+PowerDNS users can either use the existing MySQL helper scripts or the HTTP
+API helper scripts in `dns_scripts/PowerDNS-API-README.md`.
+
+If you installed only `/usr/local/bin/getssl`, remember to copy the helper
+scripts to a local directory first, for example:
+
+```sh
+install -d /usr/local/share/getssl/dns_scripts
+install -m 755 dns_scripts/dns_add_pdns-api /usr/local/share/getssl/dns_scripts/
+install -m 755 dns_scripts/dns_del_pdns-api /usr/local/share/getssl/dns_scripts/
+```
+
+and then reference them in your `getssl.cfg`:
+
+```sh
+DNS_ADD_COMMAND="/usr/local/share/getssl/dns_scripts/dns_add_pdns-api"
+DNS_DEL_COMMAND="/usr/local/share/getssl/dns_scripts/dns_del_pdns-api"
+```
 
 ## ISPConfig
 
@@ -717,6 +752,7 @@ for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_
 'dns_scripts/DNS_IONOS.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
 'dns_scripts/DNS_ROUTE53.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
 'dns_scripts/GoDaddy-README.txt' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
+'dns_scripts/PowerDNS-API-README.md' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/PowerDNS-API-README.md'
 'dns_scripts/dns_add_acmedns' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_acmedns'
 'dns_scripts/dns_add_azure' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_azure'
 'dns_scripts/dns_add_challtestsrv' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
@@ -737,6 +773,7 @@ for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_
 'dns_scripts/dns_add_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_manual'
 'dns_scripts/dns_add_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
 'dns_scripts/dns_add_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_ovh'
+'dns_scripts/dns_add_pdns-api' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_pdns-api'
 'dns_scripts/dns_add_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
 'dns_scripts/dns_add_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_vultr'
 'dns_scripts/dns_add_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
@@ -759,6 +796,7 @@ for dir in *_scripts; do install -dv /root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_
 'dns_scripts/dns_del_manual' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_manual'
 'dns_scripts/dns_del_nsupdate' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
 'dns_scripts/dns_del_ovh' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_ovh'
+'dns_scripts/dns_del_pdns-api' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_pdns-api'
 'dns_scripts/dns_del_pdns-mysql' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
 'dns_scripts/dns_del_vultr' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_vultr'
 'dns_scripts/dns_del_windows_dns_server' -> '/root/rpmbuild/BUILDROOT/getssl-2.49-1.x86_64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'
@@ -864,6 +902,7 @@ for dir in *_scripts; do install -dv /root/debbuild/BUILDROOT/getssl-2.49-1.amd6
 'dns_scripts/DNS_IONOS.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/DNS_IONOS.md'
 'dns_scripts/DNS_ROUTE53.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/DNS_ROUTE53.md'
 'dns_scripts/GoDaddy-README.txt' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/GoDaddy-README.txt'
+'dns_scripts/PowerDNS-API-README.md' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/PowerDNS-API-README.md'
 'dns_scripts/dns_add_acmedns' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_acmedns'
 'dns_scripts/dns_add_azure' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_azure'
 'dns_scripts/dns_add_challtestsrv' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_challtestsrv'
@@ -884,6 +923,7 @@ for dir in *_scripts; do install -dv /root/debbuild/BUILDROOT/getssl-2.49-1.amd6
 'dns_scripts/dns_add_manual' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_manual'
 'dns_scripts/dns_add_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_nsupdate'
 'dns_scripts/dns_add_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_ovh'
+'dns_scripts/dns_add_pdns-api' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_pdns-api'
 'dns_scripts/dns_add_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_pdns-mysql'
 'dns_scripts/dns_add_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_vultr'
 'dns_scripts/dns_add_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_add_windows_dns_server'
@@ -906,6 +946,7 @@ for dir in *_scripts; do install -dv /root/debbuild/BUILDROOT/getssl-2.49-1.amd6
 'dns_scripts/dns_del_manual' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_manual'
 'dns_scripts/dns_del_nsupdate' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_nsupdate'
 'dns_scripts/dns_del_ovh' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_ovh'
+'dns_scripts/dns_del_pdns-api' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_pdns-api'
 'dns_scripts/dns_del_pdns-mysql' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_pdns-mysql'
 'dns_scripts/dns_del_vultr' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_vultr'
 'dns_scripts/dns_del_windows_dns_server' -> '/root/debbuild/BUILDROOT/getssl-2.49-1.amd64/usr/share/getssl/dns_scripts/dns_del_windows_dns_server'

--- a/dns_scripts/PowerDNS-API-README.md
+++ b/dns_scripts/PowerDNS-API-README.md
@@ -1,0 +1,38 @@
+# PowerDNS API
+
+These helper scripts use the PowerDNS HTTP API for DNS-01 validation.
+
+## Requirements
+
+- PowerDNS authoritative server with the HTTP API enabled
+- `curl`
+- `jq`
+
+## Environment
+
+Set these environment variables before running `getssl`:
+
+- `PDNS_API_URL`
+  Example: `https://ns1.example.com/pdns`
+- `PDNS_API_KEY`
+  API token for the PowerDNS server
+
+Optional:
+
+- `PDNS_SERVER_ID`
+  Default: `localhost`
+- `PDNS_TTL`
+  Default: `120`
+
+## Example `getssl.cfg`
+
+```sh
+VALIDATE_VIA_DNS="true"
+DNS_ADD_COMMAND="/usr/share/getssl/dns_scripts/dns_add_pdns-api"
+DNS_DEL_COMMAND="/usr/share/getssl/dns_scripts/dns_del_pdns-api"
+
+export PDNS_API_URL="https://ns1.example.com/pdns"
+export PDNS_API_KEY="your-api-token"
+# export PDNS_SERVER_ID="localhost"
+# export PDNS_TTL="120"
+```

--- a/dns_scripts/dns_add_pdns-api
+++ b/dns_scripts/dns_add_pdns-api
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="${PDNS_API_URL:-}"
+api_key="${PDNS_API_KEY:-}"
+server_id="${PDNS_SERVER_ID:-localhost}"
+ttl="${PDNS_TTL:-120}"
+
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$api_url" ]]; then
+  echo "PDNS_API_URL variable not set"
+  exit 1
+fi
+if [[ -z "$api_key" ]]; then
+  echo "PDNS_API_KEY variable not set"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq command not found"
+  exit 1
+fi
+
+api_get() {
+  curl --silent -X GET "${1}" \
+    -H "X-API-Key: ${api_key}"
+}
+
+find_zone() {
+  local domain="${1}"
+  local candidate="${domain}"
+  while [[ "${candidate}" == *"."* ]]; do
+    response=$(curl --silent "${api_url%/}/api/v1/servers/${server_id}/zones/${candidate}." \
+      -H "X-API-Key: ${api_key}" \
+      -o /dev/null \
+      -w '%{http_code}')
+    if [[ "$response" == "200" ]]; then
+      printf '%s.\n' "${candidate}"
+      return 0
+    fi
+    candidate="$(echo "${candidate}" | cut -d. -f1 --complement)"
+  done
+  return 1
+}
+
+zone_name=$(find_zone "$fulldomain")
+if [[ -z "$zone_name" ]]; then
+  echo "Cannot find matching PowerDNS zone"
+  exit 1
+fi
+
+txtname="_acme-challenge.${fulldomain}."
+
+zone_data=$(api_get "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}")
+
+records=$(echo "$zone_data" | jq -c --arg txtname "$txtname" --arg token "$token" '
+  [
+    .rrsets[]? 
+    | select(.name == $txtname and .type == "TXT")
+    | .records[]?.content
+  ] as $existing
+  | ($existing + [$token | @json] | unique)
+  | map({content: ., disabled: false})
+')
+
+payload=$(jq -cn \
+  --arg txtname "$txtname" \
+  --argjson ttl "${ttl}" \
+  --argjson records "$records" \
+  '{rrsets:[{changetype:"REPLACE",name:$txtname,type:"TXT",ttl:$ttl,records:$records}]}')
+
+response=$(curl --silent -X PATCH "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}" \
+  -H 'Content-Type: application/json' \
+  -H "X-API-Key: ${api_key}" \
+  -d "$payload" \
+  -o /dev/null -w '%{http_code}')
+
+if [[ "$response" != "204" ]]; then
+  echo "Record not created"
+  echo "Response code: $response"
+  exit 1
+fi
+
+curl --silent -X PUT "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}/notify" \
+  -H "X-API-Key: ${api_key}" \
+  -o /dev/null

--- a/dns_scripts/dns_del_pdns-api
+++ b/dns_scripts/dns_del_pdns-api
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+fulldomain="${1}"
+token="${2}"
+api_url="${PDNS_API_URL:-}"
+api_key="${PDNS_API_KEY:-}"
+server_id="${PDNS_SERVER_ID:-localhost}"
+ttl="${PDNS_TTL:-120}"
+
+if [[ -z "$fulldomain" ]]; then
+  echo "DNS script requires full domain name as first parameter"
+  exit 1
+fi
+if [[ -z "$token" ]]; then
+  echo "DNS script requires challenge token as second parameter"
+  exit 1
+fi
+if [[ -z "$api_url" ]]; then
+  echo "PDNS_API_URL variable not set"
+  exit 1
+fi
+if [[ -z "$api_key" ]]; then
+  echo "PDNS_API_KEY variable not set"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq command not found"
+  exit 1
+fi
+
+api_get() {
+  curl --silent -X GET "${1}" \
+    -H "X-API-Key: ${api_key}"
+}
+
+find_zone() {
+  local domain="${1}"
+  local candidate="${domain}"
+  while [[ "${candidate}" == *"."* ]]; do
+    response=$(curl --silent "${api_url%/}/api/v1/servers/${server_id}/zones/${candidate}." \
+      -H "X-API-Key: ${api_key}" \
+      -o /dev/null \
+      -w '%{http_code}')
+    if [[ "$response" == "200" ]]; then
+      printf '%s.\n' "${candidate}"
+      return 0
+    fi
+    candidate="$(echo "${candidate}" | cut -d. -f1 --complement)"
+  done
+  return 1
+}
+
+zone_name=$(find_zone "$fulldomain") || exit 0
+txtname="_acme-challenge.${fulldomain}."
+
+zone_data=$(api_get "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}")
+
+record_count=$(echo "$zone_data" | jq -r --arg txtname "$txtname" '
+  [
+    .rrsets[]?
+    | select(.name == $txtname and .type == "TXT")
+    | .records[]?.content
+  ] | length
+')
+
+if [[ "$record_count" == "0" ]]; then
+  exit 0
+fi
+
+remaining=$(echo "$zone_data" | jq -c --arg txtname "$txtname" --arg token "$token" '
+  [
+    .rrsets[]?
+    | select(.name == $txtname and .type == "TXT")
+    | .records[]?
+    | select(.content != ($token | @json))
+    | {content: .content, disabled: false}
+  ]
+')
+
+if [[ "$remaining" == "[]" ]]; then
+  payload=$(jq -cn \
+    --arg txtname "$txtname" \
+    '{rrsets:[{changetype:"DELETE",name:$txtname,type:"TXT"}]}')
+else
+  payload=$(jq -cn \
+    --arg txtname "$txtname" \
+    --argjson ttl "${ttl}" \
+    --argjson records "$remaining" \
+    '{rrsets:[{changetype:"REPLACE",name:$txtname,type:"TXT",ttl:$ttl,records:$records}]}')
+fi
+
+response=$(curl --silent -X PATCH "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}" \
+  -H 'Content-Type: application/json' \
+  -H "X-API-Key: ${api_key}" \
+  -d "$payload" \
+  -o /dev/null -w '%{http_code}')
+
+if [[ "$response" != "204" ]]; then
+  echo "Record not deleted"
+  echo "Response code: $response"
+  exit 1
+fi
+
+curl --silent -X PUT "${api_url%/}/api/v1/servers/${server_id}/zones/${zone_name}/notify" \
+  -H "X-API-Key: ${api_key}" \
+  -o /dev/null


### PR DESCRIPTION
Add PowerDNS HTTP API DNS-01 helpers for `getssl`

This adds `dns_add_pdns-api` and `dns_del_pdns-api` helper scripts for DNS validation against the PowerDNS HTTP API, alongside a short README for configuration and usage. It also updates the main README to mention the new helper and clarify helper-script install locations for both standalone and packaged installs.