### PR TITLE
RFC 8555 validation and security improvements

### DIFF
--- a/getssl
+++ b/getssl
@@ -1517,7 +1517,7 @@ for d in "${alldomains[@]}"; do
       keyauthorization="$token.$thumbprint"
 
       # defense-in-depth: strip path traversal components from token
-      token=$(basename "$token")
+      token=$(basename -- "$token")
 
       # save variable into temporary file
       echo -n "$keyauthorization" > "$TEMP_DIR/$token"

--- a/getssl
+++ b/getssl
@@ -979,6 +979,16 @@ clean_up() { # Perform pre-exit housekeeping
   fi
 }
 
+validate_token() { # validate token per RFC 8555 §8.3: base64url alphabet, max 255 chars
+  local token="$1"
+  if [[ ${#token} -gt 255 ]]; then
+    error_exit "Invalid token: exceeds 255 character maximum (RFC 8555)"
+  fi
+  if [[ ! "$token" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    error_exit "Invalid token: contains characters outside base64url alphabet (RFC 8555)"
+  fi
+}
+
 copy_file_to_location() { # copies a file, using scp, sftp or ftp if required.
   cert=$1   # descriptive name, just used for display
   from=$2   # current file location
@@ -1426,12 +1436,14 @@ for d in "${alldomains[@]}"; do
         # get the dns component of the ACME response
         # get the token and uri from the dns component
         token=$(json_get "$response" "token" "dns-01")
+        validate_token "$token"
         uri=$(json_get "$response" "uri" "dns-01")
         debug uri "$uri"
       else # APIv2
         debug "authlink response = ${response//[$'\t\r\n']}"
         # get the token and uri from the dns-01 component
         token=$(json_get "$response" "challenges" "type" "dns-01" '"token"')
+        validate_token "$token"
         uri=$(json_get "$response" "challenges" "type" "dns-01" '"url"')
         debug uri "$uri"
       fi
@@ -1487,6 +1499,7 @@ for d in "${alldomains[@]}"; do
       if [[ $API -eq 1 ]]; then
         # get the token from the http component
         token=$(json_get "$response" "token" "http-01")
+        validate_token "$token"
         # get the uri from the http component
         uri=$(json_get "$response" "uri" "http-01")
         debug uri "$uri"
@@ -1494,6 +1507,7 @@ for d in "${alldomains[@]}"; do
         debug "authlink response = ${response//[$'\t\r\n']}"
         # get the token from the http-01 component
         token=$(json_get "$response" "challenges" "type" "http-01" '"token"')
+        validate_token "$token"
         # get the uri from the http component
         uri=$(json_get "$response" "challenges" "type" "http-01" '"url"' | head -n1)
         debug uri "$uri"
@@ -1501,6 +1515,9 @@ for d in "${alldomains[@]}"; do
 
       #create signed authorization key from token.
       keyauthorization="$token.$thumbprint"
+
+      # defense-in-depth: strip path traversal components from token
+      token=$(basename "$token")
 
       # save variable into temporary file
       echo -n "$keyauthorization" > "$TEMP_DIR/$token"

--- a/test/u12-test-validate_token.bats
+++ b/test/u12-test-validate_token.bats
@@ -1,0 +1,161 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+
+# This is run for every test
+setup() {
+    [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
+
+    . /getssl/getssl --source
+    export API=2
+    _USE_DEBUG=1
+}
+
+
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+}
+
+
+# Valid tokens
+
+@test "validate_token: accept valid base64url token (no padding)" {
+    run validate_token "kD1H4FVIEFvkWghLlKFoSPpR5u0FTGkRs4A_FnTfv3A"
+    assert_success
+    assert_output ""
+}
+
+
+@test "validate_token: accept token with dashes" {
+    run validate_token "abc-xyz-123"
+    assert_success
+    assert_output ""
+}
+
+
+@test "validate_token: accept token with underscores" {
+    run validate_token "abc_xyz_123"
+    assert_success
+    assert_output ""
+}
+
+
+@test "validate_token: accept single character token" {
+    run validate_token "a"
+    assert_success
+    assert_output ""
+}
+
+
+@test "validate_token: accept maximum length token (255 chars)" {
+    token=$(printf 'a%.0s' {1..255})
+    run validate_token "$token"
+    assert_success
+}
+
+
+# Invalid tokens
+
+@test "validate_token: reject token with semicolon" {
+    run validate_token "abc;touch /tmp/pwned"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with path traversal" {
+    run validate_token "../../../etc/passwd"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with backticks" {
+    run validate_token 'abc`touch /tmp/pwned`'
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with command substitution" {
+    run validate_token 'abc$(touch /tmp/pwned)'
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with pipe" {
+    run validate_token "abc|sh"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with spaces" {
+    run validate_token "abc def"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with forward slash" {
+    run validate_token "abc/def"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with newline" {
+    run validate_token "$(echo -e 'abc\ndef')"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token exceeding 255 characters" {
+    token=$(printf 'a%.0s' {1..256})
+    run validate_token "$token"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject empty token" {
+    run validate_token ""
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with equals sign (base64 padding)" {
+    # RFC 8555 requires trailing '=' to be stripped
+    run validate_token "abc123=="
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+# Negative assertions: tokens that should NOT match the regex
+
+@test "validate_token: reject token with ampersand" {
+    run validate_token "abc&def"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with hash" {
+    run validate_token "abc#def"
+    assert_failure
+    assert_output --partial "Invalid token"
+}
+
+
+@test "validate_token: reject token with null byte" {
+    # bash truncates at null byte in function arguments, so validate_token
+    # receives only "abc" which would pass. Use printf to preserve the null.
+    skip "bash truncates null bytes in function arguments"
+}


### PR DESCRIPTION
* Validate token per RFC 8555 §8.3: base64url alphabet, max 255 chars
* Fix 2-3 reachable bugs as a result of lax token validation
* Tests