### PR TITLE
Move loop_limit variable init to up one level of loop

### DIFF
--- a/getssl
+++ b/getssl
@@ -2943,6 +2943,12 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
       debug "bad nonce"
       nonce=$(echo "$responseHeaders" | grep -i "^replay-nonce:" | awk '{print $2}' | tr -d '\r\n ')
       debug "trying new nonce $nonce"
+      # Need to decrement the loop limit here as well to fix the infinite loop (see PR #902 and test/43-test-acme-400-error-loop) 
+      debug "loop_limit = $loop_limit"
+      loop_limit=$((loop_limit - 1))
+      if [[ $loop_limit -lt 1 ]]; then
+        error_exit "$code error from ACME server: $response"
+      fi
     else
       nonceproblem="false"
     fi

--- a/getssl
+++ b/getssl
@@ -1370,7 +1370,8 @@ date_rfc3339() { # convert rfc3339 format date into epoch time
     convdate=$(printf "%s\n" "$convdate" | sed 's/[+-][0-9]\{4\}$//')
     date -D "%Y-%m-%dT%H:%M:%S" -d "$convdate" +%s
   else
-    date -d "$convdate" +%s
+    # convert date "<date>T<time>" to epoch, fallback to "<date> <time>" to support old coreutils date on Centos6
+    date -d "$convdate" +%s || date -d "${convdate/T/ }" +%s || error_exit "Failed to parse date ${convdate}"
   fi
 }
 

--- a/getssl
+++ b/getssl
@@ -2841,6 +2841,7 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
     nonce=$($CURL -I "$URL_newNonce" | grep -i "^Replay-Nonce:" | awk '{print $2}' | tr -d '\r\n ')
   fi
 
+  loop_limit=5
   nonceproblem="true"
   while [[ "$nonceproblem" == "true" ]]; do
 
@@ -2881,7 +2882,6 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
     fi
 
     code="500"
-    loop_limit=5
     while [[ "$code" == 5* ]]; do
       if [[ "$outfile" ]] ; then
         $CURL -X POST -H "Content-Type: application/jose+json" --data "$body" "$url" > "$outfile"

--- a/test/43-test-acme-400-error-loop.bats
+++ b/test/43-test-acme-400-error-loop.bats
@@ -18,7 +18,7 @@ setup() {
 
     # 1. Create smart mock curl
     cat << 'MOCK_CURL' > /getssl/test/curl
-#!/bin/bash
+#!/usr/bin/env bash
 # Only mock if explicitly enabled AND it's a POST request (ACME requests)
 echo "# Inside mock curl" >> /tmp/mock.out
 if [[ "$GETSSL_MOCK_500" == "1" ]] && [[ "$*" == *"-X POST"* ]]; then
@@ -53,7 +53,7 @@ MOCK_CURL
 
     # 2. Create smart mock sleep (only intercepts the exact 30s loop delay)
     cat << 'MOCK_SLEEP' > /getssl/test/sleep
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$1" == "30" ]]; then
   exit 0
 else
@@ -81,7 +81,7 @@ setup_file() {
     export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
 }
 
-@test "getssl should exit with error after 5 retries on persistent 500 error" {
+@test "getssl should exit with error after 5 retries on persistent 400 error" {
     if [ -n "$STAGING" ]; then
         skip "Using staging server, skipping internal test"
     fi

--- a/test/43-test-acme-400-error-loop.bats
+++ b/test/43-test-acme-400-error-loop.bats
@@ -1,0 +1,112 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+# PR #902
+# This is to test for regressions to a fix to send_signed_request()
+# If there is a malformed request to the server which returns an error code != 5* and the response includes the message "bad:Nonce" 
+# then getssl enters an infinite loop.  This should only happen when testing code changes, but fixing just in case
+ 
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+}
+
+setup() {
+    [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
+
+    # 1. Create smart mock curl
+    cat << 'MOCK_CURL' > /getssl/test/curl
+#!/bin/bash
+# Only mock if explicitly enabled AND it's a POST request (ACME requests)
+echo "# Inside mock curl" >> /tmp/mock.out
+if [[ "$GETSSL_MOCK_500" == "1" ]] && [[ "$*" == *"-X POST"* ]]; then
+  DUMP_HEADER=""
+  # Parse arguments without destroying $@ so we can still passthrough if needed
+  args=("$@")
+  for (( i=0; i<${#args[@]}; i++ )); do
+    case "${args[$i]}" in
+      --dump-header)
+        DUMP_HEADER="${args[$((i+1))]}"
+        break
+        ;;
+    esac
+  done
+
+  if [[ -n "$DUMP_HEADER" ]]; then
+    echo "HTTP/1.1 400 Internal Server Error" > "$DUMP_HEADER"
+    echo "Replay-Nonce: mock-nonce-123" >> "$DUMP_HEADER"
+    echo "Content-Type: application/json" >> "$DUMP_HEADER"
+    echo "" >> "$DUMP_HEADER"
+  fi
+  echo '{"type": "urn:ietf:params:acme:error:badNonce:serverInternal", "detail": "Mock ACME server 400 error for testing loop_limit", "status": 400}'
+  exit 0
+else
+  # Passthrough to real curl for HEAD requests (nonce fetch), GETs, etc.
+  export PATH="${PATH#/getssl/test:}"
+  REAL_CURL=$(command -v curl)
+  exec "$REAL_CURL" "$@"
+fi
+MOCK_CURL
+    chmod +x /getssl/test/curl
+
+    # 2. Create smart mock sleep (only intercepts the exact 30s loop delay)
+    cat << 'MOCK_SLEEP' > /getssl/test/sleep
+#!/bin/bash
+if [[ "$1" == "30" ]]; then
+  exit 0
+else
+  export PATH="${PATH#/getssl/test:}"
+  REAL_SLEEP=$(command -v sleep)
+  exec "$REAL_SLEEP" "$@"
+fi
+MOCK_SLEEP
+    chmod +x /getssl/test/sleep
+
+    # 3. Prepend test directory to PATH to activate mocks
+    export PATH="/getssl/test:$PATH"
+}
+
+setup_file() {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal ARI/Pebble test"
+    fi
+
+    # Timeout the test after 60 seconds to catch any regression where the loop_limit
+    # guard fails and an infinite loop occurs. With the smart mocks, this test should
+    # naturally complete in < 1 second.
+    export BATS_TEST_TIMEOUT=60
+
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+}
+
+@test "getssl should exit with error after 5 retries on persistent 500 error" {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal test"
+    fi
+
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+
+    # Normal initialization uses real curl (mock is inactive)
+    init_getssl
+
+    # 4. Enable the 500 mock ONLY for the certificate creation step
+    export GETSSL_MOCK_500=1
+
+    # We expect this to fail because of the persistent 500 errors
+    #run /getssl/getssl -U -d "$GETSSL_CMD_HOST"
+    create_certificate
+
+    unset GETSSL_MOCK_500
+
+    # 5. Assertions
+    assert_failure
+
+    # Verify it attempted to retry (checks the loop is actually executing)
+    assert_output --regexp "loop_limit = 1"
+
+    # Verify the loop_limit guard triggered and aborted cleanly instead of looping infinitely
+    assert_output --regexp "400 error from ACME server"
+}


### PR DESCRIPTION
If you send a completely invalid message, the current code will infinitely loop.  This is because the first message will fail with a 500 error code, but the second retry will fail with an invalid nonce and restart the whole message loop, resetting loop_limit. Moving the loop_limit initialization up one level to the next outer loop stops the infinite looping.