### PR TITLE
date_rfc3339: silence expected error on CentOS 6

### DIFF
--- a/getssl
+++ b/getssl
@@ -1370,7 +1370,7 @@ date_rfc3339() { # convert rfc3339 format date into epoch time
     date -D "%Y-%m-%dT%H:%M:%S" -d "$convdate" +%s
   else
     # convert date "<date>T<time>" to epoch, fallback to "<date> <time>" to support old coreutils date on Centos6
-    date -d "$convdate" +%s || date -d "${convdate/T/ }" +%s || error_exit "Failed to parse date ${convdate}"
+    date -d "$convdate" +%s 2>/dev/null || date -d "${convdate/T/ }" +%s || error_exit "Failed to parse date ${convdate}"
   fi
 }
 

--- a/getssl
+++ b/getssl
@@ -298,6 +298,7 @@
 # 2026-06-11 Add ARI support to getssl (kenh)(#894)
 # 2026-06-15 Move loop_limit variable init to fix infinite loop (kenh)(#902)
 # 2026-06-17 Improve profile support (kenh)(#901)(2.51)
+# 2026-06-25 Improve CentOS 6 date support (combolek)(#907)
 # ----------------------------------------------------------------------------------------
 
 case :$SHELLOPTS: in


### PR DESCRIPTION
The CentOS 6 fallback in `date_rfc3339()` was working but it was always producing error output on stderr, which was not great when running from a cron job (which sends e-mail if there is any output).