### PR TITLE
Update test OS versions, README updates, add test for ARI already renewed

### DIFF
--- a/.github/workflows/run-tests-pebble.yml
+++ b/.github/workflows/run-tests-pebble.yml
@@ -84,8 +84,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Build the docker compose stack
         run: docker compose up -d --build
-      - name: Run test suite on RockyLinux8
-        run: test/run-test.sh rockylinux8
+      - name: Run test suite on RockyLinux10
+        run: test/run-test.sh rockylinux10
   test-ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -94,22 +94,6 @@ jobs:
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu
         run: test/run-test.sh ubuntu
-  test-ubuntu14:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build the docker compose stack
-        run: docker compose up -d --build
-      - name: Run test suite on Ubuntu14
-        run: test/run-test.sh ubuntu14
-  test-ubuntu16:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build the docker compose stack
-        run: docker compose up -d --build
-      - name: Run test suite on Ubuntu16
-        run: test/run-test.sh ubuntu16
   test-ubuntu18:
     runs-on: ubuntu-latest
     steps:
@@ -118,3 +102,27 @@ jobs:
         run: docker compose up -d --build
       - name: Run test suite on Ubuntu18
         run: test/run-test.sh ubuntu18
+  test-ubuntu20:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
+      - name: Run test suite on Ubuntu20
+        run: test/run-test.sh ubuntu20
+  test-ubuntu22:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
+      - name: Run test suite on Ubuntu22
+        run: test/run-test.sh ubuntu22
+  test-ubuntu24:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build the docker compose stack
+        run: docker compose up -d --build
+      - name: Run test suite on Ubuntu24
+        run: test/run-test.sh ubuntu24

--- a/README
+++ b/README
@@ -116,8 +116,8 @@ certificate
 
     ### **RPM Based Packages (RedHat, CentOS, SuSe, Oracle Linux, AWS Linux)**
 
-    - [getssl-2.51-1.src.rpm](https://github.com/srvrco/getssl/releases/download/2.51/getssl-2.51-1.src.rpm) (source)
-    - [getssl-2.51-1.noarch.rpm](https://github.com/srvrco/getssl/releases/download/2.51/getssl-2.51-1.noarch.rpm) (binary)
+    - [getssl-2.51-1.src.rpm](https://github.com/srvrco/getssl/releases/download/v2.51/getssl-2.51-1.src.rpm) (source)
+    - [getssl-2.51-1.noarch.rpm](https://github.com/srvrco/getssl/releases/download/v2.51/getssl-2.51-1.noarch.rpm) (binary)
 
     ### **Debian Based Packages (Debian, Ubuntu)**
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ For example, the release v2.51 contains the following packages in the release se
 
 ### **RPM Based Packages (RedHat, CentOS, SuSe, Oracle Linux, AWS Linux)**
 
-- [getssl-2.51-1.src.rpm](https://github.com/srvrco/getssl/releases/download/2.51/getssl-2.51-1.src.rpm) (source)
-- [getssl-2.51-1.noarch.rpm](https://github.com/srvrco/getssl/releases/download/2.51/getssl-2.51-1.noarch.rpm) (binary)
+- [getssl-2.51-1.src.rpm](https://github.com/srvrco/getssl/releases/download/v2.51/getssl-2.51-1.src.rpm) (source)
+- [getssl-2.51-1.noarch.rpm](https://github.com/srvrco/getssl/releases/download/v2.51/getssl-2.51-1.noarch.rpm) (binary)
 
 ### **Debian Based Packages (Debian, Ubuntu)**
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Obtain SSL certificates from the letsencrypt.org ACME server. Suitable
 for automating the process on remote servers.
 
 ## Table of Contents <!-- omit in toc -->
+
 - [Upgrade broken in v2.43](#upgrade-broken-in-v243)
 - [Features](#features)
 - [Overview](#overview)
@@ -26,11 +27,6 @@ for automating the process on remote servers.
 - [Include Root certificate in full chain](#include-root-certificate-in-full-chain)
 - [Windows Server and IIS Support](#windows-server-and-iis-support)
 - [Issues / problems / help](#issues--problems--help)
-
-## Upgrade broken in v2.43
-
-The automatic upgrade in v2.43 is broken as the url is incorrect.  If you have this version installed you'll need to manually upgrade using:
-```curl --silent --user-agent getssl/manual https://raw.githubusercontent.com/srvrco/getssl/latest/getssl --output getssl```
 
 ## Features
 
@@ -732,6 +728,11 @@ FULL_CHAIN_INCLUDE_ROOT="true"
     -   `RELOAD_CMD=("powershell.exe -ExecutionPolicy Bypass -File "\\\\wsl$\\Ubuntu\\home\\user\\getssl\\other_scripts\\iis_install_certeficate.ps1" "domain.eu" "IIS SiteName" "\\\\wsl$\\Ubuntu\\home\\user\\ssl\\" "path_to_ssl_dir" )`
 -   GIT and Rtools4 Bash
     -   `RELOAD_CMD=("powershell.exe /c/Users/Administrator/getssl/other_scripts/iis_install_certeficate.ps1 domain.eu domain path_to_ssl_dir")`
+
+## Upgrade broken in v2.43
+
+The automatic upgrade in v2.43 is broken as the url is incorrect.  If you have this version installed you'll need to manually upgrade using:
+```curl --silent --user-agent getssl/manual https://raw.githubusercontent.com/srvrco/getssl/latest/getssl --output getssl```
 
 ## Issues / problems / help
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,16 +17,20 @@
 ## Create a PR to Merge the release_2_nn branch into main
 
 1. `gh auth login` - need to login via browser as Personal token doesn't have enough permissions
-2. `gh pr create --draft --title "Release 2.nn" --body "Release 2.nn"`
+2. `gh pr create --title "Release 2.nn" --body "Release 2.nn"`
+3. `gh pr merge`
+4. Wait for the tests to finish
 
 ## Build the .deb and .rpm packages
 
-1. Create the release and deb/rpm packages using the deploy github action `gh workflow run "Deploy getssl" --field tags=v2.nn`
-2. Wait for the build process to finish `gh release view v2.nn`
+1. Create the release and deb/rpm packages using the deploy github action `gh workflow run "Deploy getssl" --field tags=2.nn` 
+2. Use `gh run list --workflow="release-and-package.yml"` to find the ID
+3. Wait for the build process to finish `gh run watch <ID>`
+4. This creates a draft release
 
-## Change the status of the release from draft to pre-release
+## Change the status of the release from draft to pre-release (so the deb and rpm packages can be downloaded)
 
-1. `gh release edit 2.nn --draft=false --prerelease`
+1. `gh release edit v2.nn --draft=false --title "Release 2.nn" --prerelease`
 
 ## Test the .deb file using the following steps
 
@@ -45,7 +49,7 @@
 
 ## Change the release from pre-release to latest
 
-1. `gh release edit v2.nn --latest`
+1. `gh release edit v2.nn --prerelease=false --latest`
 
 ## Update the latest tag post-release
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       # with Go 1.13.x which defaults TLS 1.3 to on
       GODEBUG: "tls13=1"
       PEBBLE_ALTERNATE_ROOTS: 2
+      PEBBLE_VA_NOSLEEP: 1
+      PEBBLE_VA_SLEEPTIME: 1
     ports:
       - 14000:14000  # HTTPS ACME API
       - 15000:15000  # HTTPS Management API

--- a/getssl
+++ b/getssl
@@ -2953,16 +2953,14 @@ send_signed_request() { # Sends a request to the ACME server, signed with your p
       if [[ $loop_limit -lt 1 ]]; then
         error_exit "$code error from ACME server: $response"
       fi
-    elif [[ $response == *"could not find an order for the given certificate"* ]] && [[ -n "$_REPLACES" ]]; then
-      # ARI renewal encountered an error because pebble couldn't find the certificate to replace, seeing this intermittently on the pebble tests and this is a quick fix
-      debug "ARI renewal error: 'could not find order' - clearing _REPLACES and retrying"
+    # Either the ACME server coun't find the certificate to replace (intermittent pebble error) or the certificate with this serial has already had a replacement (#908),
+    # in both scenarios, clear the replace serial from the order and try again.
+    elif [[ ( $response == *"could not find an order for the given certificate"* \
+       || $response == *"error:alreadyReplaced"* ) ]] && [[ -n "$_REPLACES" ]]; then
+      debug "ARI renewal error - clearing replaces from payload and retrying (response: $response)"
       # Remove , "replaces": "..." from the payload
       payload="${payload//, \"replaces\": \"$_REPLACES\"/}"
-    elif [[ $response == *"error:alreadyReplaced"* ]] && [[ -n "$_REPLACES" ]]; then
-      # ARI renewal encountered an error because certificate with serial $serialb64 already has a replacement order
-      debug "ARI renewal error: 'could not validate ARI 'replaces' field' - clearing _REPLACES and retrying"
-      # Remove , "replaces": "..." from the payload
-      payload="${payload//, \"replaces\": \"$_REPLACES\"/}"
+      _REPLACES=""
     else
       nonceproblem="false"
     fi

--- a/test/43-test-acme-400-error-loop.bats
+++ b/test/43-test-acme-400-error-loop.bats
@@ -11,12 +11,15 @@ load '/getssl/test/test_helper.bash'
  
 teardown() {
     [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+    rm /getssl/test/curl
+    rm /tmp/mock.out
 }
 
 setup() {
     [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
 
-    # 1. Create smart mock curl
+    # Create mock curl for ACME POST requests (testing loop_limit guard; see PR #902).
+    # Activates against the /getssl/test PATH already configured by test_helper.bash.
     cat << 'MOCK_CURL' > /getssl/test/curl
 #!/usr/bin/env bash
 # Only mock if explicitly enabled AND it's a POST request (ACME requests)
@@ -50,22 +53,6 @@ else
 fi
 MOCK_CURL
     chmod +x /getssl/test/curl
-
-    # 2. Create smart mock sleep (only intercepts the exact 30s loop delay)
-    cat << 'MOCK_SLEEP' > /getssl/test/sleep
-#!/usr/bin/env bash
-if [[ "$1" == "30" ]]; then
-  exit 0
-else
-  export PATH="${PATH#/getssl/test:}"
-  REAL_SLEEP=$(command -v sleep)
-  exec "$REAL_SLEEP" "$@"
-fi
-MOCK_SLEEP
-    chmod +x /getssl/test/sleep
-
-    # 3. Prepend test directory to PATH to activate mocks
-    export PATH="/getssl/test:$PATH"
 }
 
 setup_file() {
@@ -73,10 +60,11 @@ setup_file() {
         skip "Using staging server, skipping internal ARI/Pebble test"
     fi
 
-    # Timeout the test after 60 seconds to catch any regression where the loop_limit
+    # Timeout the test after 120 seconds to catch any regression where the loop_limit
     # guard fails and an infinite loop occurs. With the smart mocks, this test should
     # naturally complete in < 1 second.
-    export BATS_TEST_TIMEOUT=60
+    # Using 1200 instead of 120 as sleep is overridden in testing to 10% of original value
+    export BATS_TEST_TIMEOUT=1200
 
     export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
 }

--- a/test/43-test-acme-400-error-loop.bats
+++ b/test/43-test-acme-400-error-loop.bats
@@ -11,8 +11,12 @@ load '/getssl/test/test_helper.bash'
  
 teardown() {
     [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
-    rm /getssl/test/curl
-    rm /tmp/mock.out
+    if [ -e /getssl/test/curl ]; then
+      rm /getssl/test/curl
+    fi
+    if [ -e /tmp/mock.out ]; then
+      rm /tmp/mock.out
+    fi
 }
 
 setup() {
@@ -64,7 +68,7 @@ setup_file() {
     # guard fails and an infinite loop occurs. With the smart mocks, this test should
     # naturally complete in < 1 second.
     # Using 1200 instead of 120 as sleep is overridden in testing to 10% of original value
-    export BATS_TEST_TIMEOUT=1200
+    # export BATS_TEST_TIMEOUT=1200
 
     export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
 }

--- a/test/44-test-ari-serverInternalError.bats
+++ b/test/44-test-ari-serverInternalError.bats
@@ -11,8 +11,12 @@ load '/getssl/test/test_helper.bash'
 
 teardown() {
     [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
-    rm /getssl/test/curl
-    rm /tmp/mock.out
+    if [ -e /getssl/test/curl ]; then
+      rm /getssl/test/curl
+    fi
+    if [ -e /tmp/mock.out]; then
+      rm /tmp/mock.out
+    fi
 }
 
 setup() {

--- a/test/44-test-ari-serverInternalError.bats
+++ b/test/44-test-ari-serverInternalError.bats
@@ -11,6 +11,8 @@ load '/getssl/test/test_helper.bash'
 
 teardown() {
     [ -n "$BATS_TEST_COMPLETED" ] || touch $BATS_RUN_TMPDIR/failed.skip
+    rm /getssl/test/curl
+    rm /tmp/mock.out
 }
 
 setup() {
@@ -78,23 +80,8 @@ else
 fi
 MOCK_CURL
     chmod +x /getssl/test/curl
-
-    # 2. Create smart mock sleep (only intercepts the exact 30s loop delay)
-    cat << 'MOCK_SLEEP' > /getssl/test/sleep
-#!/usr/bin/env bash
-if [[ "$1" == "30" ]]; then
-  exit 0
-else
-  export PATH="${PATH#/getssl/test:}"
-  REAL_SLEEP=$(command -v sleep)
-  exec "$REAL_SLEEP" "$@"
-fi
-MOCK_SLEEP
-    chmod +x /getssl/test/sleep
-
-    # 3. Prepend test directory to PATH to activate mocks
-    export PATH="/getssl/test:$PATH"
 }
+
 
 setup_file() {
     if [ -n "$STAGING" ]; then

--- a/test/45-test-ari-duplicate-replacement.bats
+++ b/test/45-test-ari-duplicate-replacement.bats
@@ -1,0 +1,80 @@
+#! /usr/bin/env bats
+
+load '/bats-support/load.bash'
+load '/bats-assert/load.bash'
+load '/getssl/test/test_helper.bash'
+
+# This test confirms a bug reported with the ARI support in #908.
+# There's an issue that if a certificate is renewed twice (e.g. if it's not updated
+# successfully) then the renewal process tries to create a new order with the
+# replaces field is a cert that had already been replaced. When this happens,
+# Let's Encrypt currently responds with HTTP 409 (Conflict) and the error
+# urn:ietf:params:acme:error:conflict
+
+
+setup() {
+    [ ! -f "$BATS_RUN_TMPDIR/failed.skip" ] || skip "skipping tests after first failure"
+}
+
+
+teardown() {
+    [ -n "$BATS_TEST_COMPLETED" ] || touch "$BATS_RUN_TMPDIR/failed.skip"
+}
+
+
+setup_file() {
+    if [ -n "$STAGING" ]; then
+        skip "Using staging server, skipping internal ARI/Pebble test"
+    fi
+    export CURL_CA_BUNDLE=/root/pebble-ca-bundle.crt
+}
+
+
+@test "ARI renewal of an already-replaced certificate returns 409 and fails" {
+    # shellcheck disable=SC2034
+    CONFIG_FILE="getssl-http01.cfg"
+    setup_environment
+    init_getssl
+    create_certificate
+    assert_success
+    check_output_for_errors
+
+    CERT=${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.crt
+    ORIGINAL_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+
+    # Save the original certificate so it can be restored after the first renewal.
+    ORIGINAL_CERT_COPY=$(mktemp)
+    cp "$CERT" "$ORIGINAL_CERT_COPY"
+
+    # 1. First renewal: open the ARI window for the original cert and renew.
+    #    This creates the replacement order on the server for the original cert.
+    configure_pebble_ari_window open "$CERT"
+    run "${CODE_DIR}/getssl" -U -d "$GETSSL_CMD_HOST"
+
+    assert_success
+    assert_line --partial "Within ARI renewal window, using ARI"
+    check_output_for_errors
+
+    RENEWED_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+    [[ "$ORIGINAL_SERIAL" != "$RENEWED_SERIAL" ]]
+
+    # 2. Restore the original certificate. The server still holds the replacement
+    #    order from step 1, keyed on the original cert's ARI identifier.
+    cp "$ORIGINAL_CERT_COPY" "$CERT"
+    RESTORED_SERIAL=$(openssl x509 -in "$CERT" -noout -serial)
+    [[ "$RESTORED_SERIAL" = "$ORIGINAL_SERIAL" ]]
+
+    # 3. Second renewal: re-open the ARI window for the restored original and
+    #    attempt to renew again. getssl reuses the original cert's ARI id as the
+    #    "replaces" value, colliding with the existing replacement order.
+    configure_pebble_ari_window open "$CERT"
+    run "${CODE_DIR}/getssl" -U -d "$GETSSL_CMD_HOST"
+
+    # The server rejects the duplicate replacement with 409 Conflict. The
+    # response body is logged in the debug output.
+    assert_output --partial "already has a replacement order"
+
+    assert_success
+
+    rm -f "$ORIGINAL_CERT_COPY"
+}

--- a/test/Dockerfile-rockylinux10
+++ b/test/Dockerfile-rockylinux10
@@ -1,10 +1,10 @@
-FROM rockylinux/rockylinux:8
+FROM rockylinux/rockylinux:10
 
 # Update and install required software
 RUN yum -y update && \
     yum -y install \
         epel-release \
-        git curl bind-utils wget which nginx jq procps findutils \
+        git curl bind-utils wget which nginx jq procps findutils openssl \
         ftp vsftpd \
         openssh-server \
         glibc-locale-source glibc-langpack-en # for en_US.UTF-8 support

--- a/test/Dockerfile-ubuntu20
+++ b/test/Dockerfile-ubuntu20
@@ -1,0 +1,43 @@
+FROM ubuntu:focal
+# focal = 20 LTS (long term support)
+
+# Set the frontend to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install required software
+RUN apt-get update --fix-missing
+RUN apt-get install -y git curl dnsutils ldnsutils wget nginx-light jq
+RUN apt-get install -y ftp vsftpd
+RUN apt-get install -y openssh-server
+RUN apt-get install -y locales # for idn testing
+
+# Set locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# Setup ftp
+ENV VSFTPD_CONF=/etc/vsftpd.conf
+ENV FTP_PASSIVE_DEFAULT=false
+COPY test/test-config/vsftpd.conf /etc/vsftpd.conf
+RUN adduser ftpuser
+RUN echo 'ftpuser:ftpuser' | chpasswd
+RUN adduser ftpuser www-data
+RUN adduser root www-data
+RUN chown -R www-data.www-data /var/www
+RUN chmod g+w -R /var/www
+
+WORKDIR /root
+
+# Prevent "Can't load /root/.rnd into RNG" error from openssl
+RUN touch /root/.rnd
+
+# BATS (Bash Automated Testings)
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /bats-core
+RUN git clone --depth 1 https://github.com/bats-core/bats-support /bats-support
+RUN git clone --depth 1 https://github.com/bats-core/bats-assert /bats-assert
+RUN /bats-core/install.sh /usr/local
+
+# Run eternal loop - for testing
+CMD [ "tail", "-f", "/dev/null" ]

--- a/test/Dockerfile-ubuntu22
+++ b/test/Dockerfile-ubuntu22
@@ -1,39 +1,37 @@
-FROM ubuntu:trusty
-# trusty = 14
+FROM ubuntu:jammy
+# Jammy Jellyfish = 22 LTS (long term support)
 
-# Note this image uses mawk
+# Set the frontend to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and install required software
-RUN apt-get update --fix-missing && \
-    apt-get install -y \
-        git curl dnsutils ldnsutils wget nginx-light jq \
-        ftp vsftpd \
-        openssh-server \
-        locales # for idn testing
+RUN apt-get update --fix-missing
+RUN apt-get install -y git curl dnsutils ldnsutils wget nginx-light jq
+RUN apt-get install -y ftp vsftpd
+RUN apt-get install -y openssh-server
+RUN apt-get install -y locales # for idn testing
 
 # Set locale
-RUN locale-gen en_US.UTF-8
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
-
-WORKDIR /root
-RUN mkdir -p /etc/nginx/pki/private
-COPY ./test/test-config/nginx-ubuntu-no-ssl /etc/nginx/sites-enabled/default
 
 # Setup ftp
 ENV VSFTPD_CONF=/etc/vsftpd.conf
 ENV FTP_PASSIVE_DEFAULT=false
 COPY test/test-config/vsftpd.conf /etc/vsftpd.conf
-# The default init.d script seems to have an incorrect check that vsftpd has started
-COPY test/test-config/vsftpd.initd /etc/init.d/vsftpd
 RUN adduser ftpuser
 RUN echo 'ftpuser:ftpuser' | chpasswd
 RUN adduser ftpuser www-data
 RUN adduser root www-data
-RUN mkdir -p /var/www
 RUN chown -R www-data.www-data /var/www
 RUN chmod g+w -R /var/www
+
+WORKDIR /root
+
+# Prevent "Can't load /root/.rnd into RNG" error from openssl
+RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /bats-core

--- a/test/Dockerfile-ubuntu24
+++ b/test/Dockerfile-ubuntu24
@@ -1,7 +1,8 @@
-FROM ubuntu:xenial
-# xenial = 16
+FROM ubuntu:noble
+# Noble Numbat = 24 LTS (long term support)
 
-# Note this image uses mawk
+# Set the frontend to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update and install required software
 RUN apt-get update --fix-missing
@@ -16,22 +17,21 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-WORKDIR /root
-RUN mkdir -p /etc/nginx/pki/private
-COPY ./test/test-config/nginx-ubuntu-no-ssl /etc/nginx/sites-enabled/default
-
 # Setup ftp
 ENV VSFTPD_CONF=/etc/vsftpd.conf
 ENV FTP_PASSIVE_DEFAULT=false
 COPY test/test-config/vsftpd.conf /etc/vsftpd.conf
-# The default init.d script seems to have an incorrect check that vsftpd has started
-COPY test/test-config/vsftpd.initd /etc/init.d/vsftpd
 RUN adduser ftpuser
 RUN echo 'ftpuser:ftpuser' | chpasswd
 RUN adduser ftpuser www-data
 RUN adduser root www-data
 RUN chown -R www-data.www-data /var/www
 RUN chmod g+w -R /var/www
+
+WORKDIR /root
+
+# Prevent "Can't load /root/.rnd into RNG" error from openssl
+RUN touch /root/.rnd
 
 # BATS (Bash Automated Testings)
 RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /bats-core

--- a/test/README-Testing.md
+++ b/test/README-Testing.md
@@ -64,8 +64,16 @@ For individual accounts, \<reponame> is your github account name.
 4. `test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
 
 Note: If curl to pebble:14000 fails, change debug-test.sh to use the pebble.minica.pem file
-
 Note: Certificates will be created in /etc/nginx/pki
+
+### To run bats on a file manually
+
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
+2. ```run-test.sh <os> bash```
+3. `cd /root`
+4. `bats /getssl/test/<test-script>.bats`
+
+Note: This doesn't work if run inside the `getssl` directory
 
 ### TODO
 

--- a/test/sleep
+++ b/test/sleep
@@ -14,7 +14,7 @@
 set -eu
 
 : "${SLEEP_REDUCTION_FACTOR:=0.9}"
-: "${SLEEP_MIN_SECONDS:=1}"
+: "${SLEEP_MIN_SECONDS:=0.1}"
 
 reduced_arg="$1"
 if [[ "$reduced_arg" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then

--- a/test/sleep
+++ b/test/sleep
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# When running pebble test/test_helper.bash updates the PATH so that 
+# every `sleep <duration>` call made by getssl is reduced by
+# SLEEP_REDUCTION_FACTOR (default 0.9, so sleep 30 -> sleep 3) and floored
+# at SLEEP_MIN_SECONDS (default 1), then delegated to the real sleep
+# binary. Non-numeric arguments (suffixed durations, multiple values, etc.)
+# are passed through untouched.
+#
+# Scope: deliberately intercepts only getssl's own propagation waits. 
+# Tests that need real timing semantics should unset SLEEP_REDUCTION_FACTOR
+# in their setup or use a different binary name.
+
+set -eu
+
+: "${SLEEP_REDUCTION_FACTOR:=0.9}"
+: "${SLEEP_MIN_SECONDS:=1}"
+
+reduced_arg="$1"
+if [[ "$reduced_arg" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    reduced_arg=$(awk -v d="$1" -v r="$SLEEP_REDUCTION_FACTOR" -v m="$SLEEP_MIN_SECONDS" \
+        'BEGIN {
+            eff = d * (1 - r)
+            if (eff < m) eff = m
+            printf "%.6f\n", eff
+        }')
+fi
+
+# Strip our own directory from PATH before delegating, to prevent recursive
+# interception. Follow the proven pattern from test/43-test-acme-400-error-loop.bats.
+export PATH="${PATH#/getssl/test:}"
+REAL_SLEEP=$(command -v sleep)
+exec "$REAL_SLEEP" "$reduced_arg"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -31,7 +31,9 @@ check_github_quota() {
     remaining="$(jq -r '.resources.core.remaining' <<<"$limits")"
     echo "# Remaining: $remaining"
     reset="$(jq -r '.resources.core.reset' <<<"$limits")"
-    if [[ "$remaining" -ge "$need" ]] ; then return 0 ; fi
+    if [[ "$remaining" -ge "$need" ]] ; then
+      return 0
+    fi
     limit="$(jq -r '.resources.core.limit' <<<"$limits")"
     echo "# Limit: $limit"
     if [[ "$limit" -lt "$need" ]] ; then
@@ -72,9 +74,10 @@ check_output_for_errors() {
   contains_whitelisted_phrase=0
   for phrase in "${whitelist_array[@]}"; do
     #echo "# DEBUG: checking output for whitelisted phrase: $phrase"
-    status=1
-    assert_output --regexp "$phrase" 2>/dev/null || status=0
-    contains_whitelisted_phrase=$((status || contains_whitelisted_phrase))
+    if grep -qE "$phrase" <<<"$output"; then
+      contains_whitelisted_phrase=1
+      break
+    fi
   done
 
   if [[ $contains_whitelisted_phrase -eq 0 ]]; then
@@ -203,4 +206,9 @@ if [ -z "$STAGING" ] && [ ! -f ${INSTALL_DIR}/pebble.minica.pem ]; then
     CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
   fi
   cat $CERT_FILE ${INSTALL_DIR}/pebble.minica.pem > ${INSTALL_DIR}/pebble-ca-bundle.crt
+fi
+
+# Mock sleep for pebble testing
+if [ -z "$STAGING" ]; then
+    export PATH="/getssl/test:$PATH"
 fi

--- a/test/u6-test-combined-directory.bats
+++ b/test/u6-test-combined-directory.bats
@@ -6,10 +6,11 @@ load '/getssl/test/test_helper.bash'
 
 # CA with a unified directory (both ACME V1 and V2 at the same URI)
 CA="https://api.test4.buypass.no/acme"
+CA="https://acme-api.actalis.com/acme/directory"
 
 # This is run for every test
 setup() {
-    skip "buypass.no has stopped selling SSL certificates"
+#    skip "buypass.no has stopped selling SSL certificates"
     [ ! -f $BATS_RUN_TMPDIR/failed.skip ] || skip "skipping tests after first failure"
 
     . /getssl/getssl --source


### PR DESCRIPTION
* Refreshes test Docker images (Ubuntu 14/16 → 20/22/24, Rocky Linux 8 → 10)
* Adds a mock sleep to try and speed up tests
* Consolidates ARI failure checks and adds a test for ARI already renewed
* Re-enables the combined-directory test against the Actalis ACME endpoint
* Fixes download links for deb and rpm files
* Updates release instructions in the README files