### PR TITLE
Make the default key algorithm ecdsa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       # with Go 1.13.x which defaults TLS 1.3 to on
       GODEBUG: "tls13=1"
       PEBBLE_ALTERNATE_ROOTS: 2
-      PEBBLE_VA_NOSLEEP: 1
       PEBBLE_VA_SLEEPTIME: 1
     ports:
       - 14000:14000  # HTTPS ACME API

--- a/getssl
+++ b/getssl
@@ -311,7 +311,7 @@ VERSION="2.51"
 
 # defaults
 ACCOUNT_KEY_LENGTH=4096
-ACCOUNT_KEY_TYPE="rsa"
+ACCOUNT_KEY_TYPE="prime256v1"
 ACME_RESPONSE_PENDING_WAIT=5
 ARI_ENABLE="true"
 CA_CERT_LOCATION=""
@@ -344,7 +344,7 @@ OCSP_MUST_STAPLE="false"
 ORIG_UMASK=$(umask)
 PREFERRED_CHAIN=""              # Set this to use an alternative root certificate
 PREVIOUSLY_VALIDATED="true"
-PRIVATE_KEY_ALG="rsa"
+PRIVATE_KEY_ALG="prime256v1"
 PROFILE=""
 RELOAD_CMD=""
 RENEW_ALLOW="30"
@@ -3171,7 +3171,7 @@ write_getssl_template() { # write out the main template file
 
 	# Account key and private key types - can be rsa, prime256v1, secp384r1 or secp521r1
 	#ACCOUNT_KEY_TYPE="rsa"
-	PRIVATE_KEY_ALG="rsa"
+	PRIVATE_KEY_ALG="prime256v1"
 	#REUSE_PRIVATE_KEY="true"
 
 	# Preferred Chain - use an different certificate root from the default

--- a/test/39-private-key-alg-changed.bats
+++ b/test/39-private-key-alg-changed.bats
@@ -29,7 +29,7 @@ teardown_file() {
     create_certificate
     assert_success
     check_output_for_errors
-    # save a coy of the private key
+    # save a copy of the private key
     cp "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.key" "${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.key.orig"
 }
 
@@ -73,7 +73,7 @@ teardown_file() {
     ORIG_KEY_HASH="$(cat ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/${GETSSL_CMD_HOST}.key | sha256sum)"
 
     cat <<- 'EOF' > ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
-PRIVATE_KEY_ALG="prime256v1"
+PRIVATE_KEY_ALG="rsa"
 EOF
 
     run ${CODE_DIR}/getssl -U -d $GETSSL_HOST

--- a/test/README-Testing.md
+++ b/test/README-Testing.md
@@ -37,46 +37,46 @@ For individual accounts, \<reponame> is your github account name.
 
 ## Testing locally using pebble
 
+1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
+
 ### To run all the tests on a single OS
 
-1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
-2. Run the test suite ```test/run-test.sh [<os>]```
-3. eg. `test/run-test.sh ubuntu16`
+Run the test suite ```test/run-test.sh [<os>]```
+eg. `test/run-test.sh ubuntu16`
 
 ### To run a single bats test on a single OS
 
-1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
-2. ```test/run-test.sh <os> bats <bats test script>```
-3. e.g. `test/run-test.sh ubuntu bats /getssl/test/1-simple-http01.bats`
+`test/run-test.sh <os> <bats test script>`
+e.g. `test/run-test.sh ubuntu test/1-simple-http01.bats`
 
-## To debug a test
+### To print the output of a test when it succeeds (automatically printed if it fails)
 
-1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
-2. ```run-test.sh <os> /getssl/test/debug-test.sh <getssl config file>```
-3. e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
-4. or (`test/run-test.sh ubuntu /getssl/test/debug-test.sh -d getssl-http01.cfg`)
+`test/run-test.sh <os> -d <test script>`
+e.g. `test/run-test.sh ubuntu -d test/1-simple-http01-dig.bats`
+
+### To debug a test
+
+`run-test.sh <os> /getssl/test/debug-test.sh <getssl config file>`
+e.g. `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
+or `test/run-test.sh ubuntu /getssl/test/debug-test.sh -d getssl-http01.cfg`
 
 ### To start a shell and debug a test
 
-1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
-2. ```run-test.sh <os> bash```
-3. `cd /getssl`
-4. `test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg`
+```bash
+run-test.sh <os> bash
+cd /getssl
+test/debug-test.sh -d /getssl/test/test-config/getssl-http01.cfg
+```
 
 Note: If curl to pebble:14000 fails, change debug-test.sh to use the pebble.minica.pem file
 Note: Certificates will be created in /etc/nginx/pki
 
 ### To run bats on a file manually
 
-1. Start `pebble` and `challtestsrv` using ```docker compose up -d --build```
-2. ```run-test.sh <os> bash```
-3. `cd /root`
-4. `bats /getssl/test/<test-script>.bats`
+```bash
+run-test.sh <os> bash
+cd /root
+bats /getssl/test/<test-script>.bats
+```
 
 Note: This doesn't work if run inside the `getssl` directory
-
-### TODO
-
-1. Test wildcards
-2. Test SSH, SFTP, SCP
-3. Test change of key algorithm (should automatically delete and re-create account.key)

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -86,15 +86,21 @@ OS=$1
 
 if [ $# -gt 1 ]; then
   shift
+  if [ $1 == "-d" ]; then
+    DEBUG="--verbose-run --show-output-of-passing-tests "
+    shift
+  else
+    DEBUG=""
+  fi
   COMMAND=$*
   if [[ $COMMAND != bash ]] && [[ $COMMAND != /getssl/test/debug-test.sh* ]]; then
     if [[ $COMMAND != "bats /getssl/test"* ]]; then
       if [[ $COMMAND == /getssl/test* ]]; then
-        COMMAND="bats $COMMAND"
+        COMMAND="bats ${DEBUG}$COMMAND"
       elif [[ $COMMAND == test/* ]]; then
-        COMMAND="bats /getssl/$COMMAND"
+        COMMAND="bats ${DEBUG}/getssl/$COMMAND"
       else
-        COMMAND="bats /getssl/test/$COMMAND"
+        COMMAND="bats ${DEBUG}/getssl/test/$COMMAND"
       fi
     fi
     if [[ $COMMAND != *.bats ]]; then
@@ -102,7 +108,7 @@ if [ $# -gt 1 ]; then
     fi
   fi
 else
-  COMMAND="bats /getssl/test --timing"
+  COMMAND="bats ${DEBUG}/getssl/test --timing"
 fi
 echo "Running $COMMAND"
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -90,6 +90,9 @@ check_output_for_errors() {
 }
 
 cleanup_environment() {
+  if [ -f ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg ]; then
+    rm ${INSTALL_DIR}/.getssl/${GETSSL_CMD_HOST}/getssl_test_specific.cfg
+  fi
   if [ -z "$STAGING" ]; then
     curl --silent -X POST -d '{"host":"'"$GETSSL_HOST"'"}' http://10.30.50.3:8055/clear-a
   fi


### PR DESCRIPTION
* Change default Key Algorithm from rsa to prime256v1 (fixes #417)
* Add 1s sleep to Pebble to fix test flakiness
* Testing - add -d to `run-test.sh` which prints test output on success